### PR TITLE
Remove `-Z install-upgrade` for cargo-audit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     cache: cargo
     rust: nightly
     install:
-    - cargo install -Z install-upgrade cargo-audit
+    - cargo install cargo-audit
     script:
     - cargo generate-lockfile -Z minimal-versions
     - cargo audit


### PR DESCRIPTION
This is now the default since https://github.com/rust-lang/cargo/pull/7560, still need to use nightly for `-Z minimal-versions` though.