### PR TITLE
Remove trait bounds on type definitions

### DIFF
--- a/src/futures/bufread/generic/decoder.rs
+++ b/src/futures/bufread/generic/decoder.rs
@@ -18,7 +18,7 @@ enum State {
 
 pin_project! {
     #[derive(Debug)]
-    pub struct Decoder<R: AsyncBufRead, D: Decode> {
+    pub struct Decoder<R, D: Decode> {
         #[pin]
         reader: R,
         decoder: D,

--- a/src/futures/bufread/generic/encoder.rs
+++ b/src/futures/bufread/generic/encoder.rs
@@ -18,7 +18,7 @@ enum State {
 
 pin_project! {
     #[derive(Debug)]
-    pub struct Encoder<R: AsyncBufRead, E: Encode> {
+    pub struct Encoder<R, E: Encode> {
         #[pin]
         reader: R,
         encoder: E,

--- a/src/futures/bufread/macros/decoder.rs
+++ b/src/futures/bufread/macros/decoder.rs
@@ -6,7 +6,7 @@ macro_rules! decoder {
             ///
             /// This structure implements an [`AsyncRead`](futures_io::AsyncRead) interface and will
             /// read compressed data from an underlying stream and emit a stream of uncompressed data.
-            pub struct $name<R: futures_io::AsyncBufRead> {
+            pub struct $name<R> {
                 #[pin]
                 inner: crate::futures::bufread::Decoder<R, crate::codec::$name>,
             }

--- a/src/futures/bufread/macros/encoder.rs
+++ b/src/futures/bufread/macros/encoder.rs
@@ -6,7 +6,7 @@ macro_rules! encoder {
             ///
             /// This structure implements an [`AsyncRead`](futures_io::AsyncRead) interface and will
             /// read uncompressed data from an underlying stream and emit a stream of compressed data.
-            pub struct $name<$inner: futures_io::AsyncBufRead> {
+            pub struct $name<$inner> {
                 #[pin]
                 inner: crate::futures::bufread::Encoder<$inner, crate::codec::$name>,
             }

--- a/src/futures/write/buf_writer.rs
+++ b/src/futures/write/buf_writer.rs
@@ -195,7 +195,7 @@ impl<W: AsyncWrite> AsyncBufWrite for BufWriter<W> {
     }
 }
 
-impl<W: AsyncWrite + fmt::Debug> fmt::Debug for BufWriter<W> {
+impl<W: fmt::Debug> fmt::Debug for BufWriter<W> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("BufWriter")
             .field("writer", &self.inner)

--- a/src/futures/write/generic/decoder.rs
+++ b/src/futures/write/generic/decoder.rs
@@ -22,7 +22,7 @@ enum State {
 
 pin_project! {
     #[derive(Debug)]
-    pub struct Decoder<W: AsyncWrite, D: Decode> {
+    pub struct Decoder<W, D: Decode> {
         #[pin]
         writer: BufWriter<W>,
         decoder: D,

--- a/src/futures/write/generic/encoder.rs
+++ b/src/futures/write/generic/encoder.rs
@@ -22,7 +22,7 @@ enum State {
 
 pin_project! {
     #[derive(Debug)]
-    pub struct Encoder<W: AsyncWrite, E: Encode> {
+    pub struct Encoder<W, E: Encode> {
         #[pin]
         writer: BufWriter<W>,
         encoder: E,

--- a/src/futures/write/macros/decoder.rs
+++ b/src/futures/write/macros/decoder.rs
@@ -6,7 +6,7 @@ macro_rules! decoder {
             ///
             /// This structure implements an [`AsyncWrite`](futures_io::AsyncWrite) interface and will
             /// take in compressed data and write it uncompressed to an underlying stream.
-            pub struct $name<W: futures_io::AsyncWrite> {
+            pub struct $name<W> {
                 #[pin]
                 inner: crate::futures::write::Decoder<W, crate::codec::$name>,
             }

--- a/src/futures/write/macros/encoder.rs
+++ b/src/futures/write/macros/encoder.rs
@@ -6,7 +6,7 @@ macro_rules! encoder {
             ///
             /// This structure implements an [`AsyncWrite`](futures_io::AsyncWrite) interface and will
             /// take in uncompressed data and write it compressed to an underlying stream.
-            pub struct $name<$inner: futures_io::AsyncWrite> {
+            pub struct $name<$inner> {
                 #[pin]
                 inner: crate::futures::write::Encoder<$inner, crate::codec::$name>,
             }

--- a/src/stream/generic/decoder.rs
+++ b/src/stream/generic/decoder.rs
@@ -23,7 +23,7 @@ enum State {
 
 pin_project! {
     #[derive(Debug)]
-    pub struct Decoder<S: Stream<Item = Result<Bytes>>, D: Decode> {
+    pub struct Decoder<S, D: Decode> {
         #[pin]
         stream: S,
         decoder: D,

--- a/src/stream/generic/encoder.rs
+++ b/src/stream/generic/encoder.rs
@@ -23,7 +23,7 @@ enum State {
 
 pin_project! {
     #[derive(Debug)]
-    pub struct Encoder<S: Stream<Item = Result<Bytes>>, E: Encode> {
+    pub struct Encoder<S, E: Encode> {
         #[pin]
         stream: S,
         encoder: E,

--- a/src/stream/macros/decoder.rs
+++ b/src/stream/macros/decoder.rs
@@ -6,7 +6,7 @@ macro_rules! decoder {
             ///
             /// This structure implements a [`Stream`](futures_core::stream::Stream) interface and will read
             /// compressed data from an underlying stream and emit a stream of uncompressed data.
-            pub struct $name<S: futures_core::stream::Stream<Item = std::io::Result<bytes::Bytes>>> {
+            pub struct $name<S> {
                 #[pin]
                 inner: crate::stream::generic::Decoder<S, crate::codec::$name>,
             }

--- a/src/stream/macros/encoder.rs
+++ b/src/stream/macros/encoder.rs
@@ -6,7 +6,7 @@ macro_rules! encoder {
             ///
             /// This structure implements a [`Stream`](futures_core::stream::Stream) interface and will read
             /// uncompressed data from an underlying stream and emit a stream of compressed data.
-            pub struct $name<$inner: futures_core::stream::Stream<Item = std::io::Result<bytes::Bytes>>> {
+            pub struct $name<$inner> {
                 #[pin]
                 inner: crate::stream::Encoder<$inner, crate::codec::$name>,
             }


### PR DESCRIPTION
This change allows downstream types to depend on `async_compression` types without extra trait bounds.

Currently, users need to write something like the following:

```rust
struct Foo<S: Stream<Item = Result<Bytes>>> {
    stream: GzipDecoder<S>,
    // ...
}
```

After this change, it becomes:

```rust
struct Foo<S> {
    stream: GzipDecoder<S>,
    // ...
}
```

The trait bounds are still enforced on the constructors, so they still prevent you from creating `*Decoder<T>` or `*Encoder<T>` values when the required trait bounds are not satisfied.