### PR TITLE
Replace `brotli2` with `brotli`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,13 @@ futures-write = ["futures-io"]
 stream = ["bytes"]
 
 # algorithms
-brotli = ["brotli2"]
 deflate = ["flate2"]
 gzip = ["flate2"]
 zlib = ["flate2"]
 zstd = ["libzstd", "zstd-safe"]
 
 [dependencies]
-brotli2 = { version = "0.3.2", optional = true }
+brotli = { version = "3.3.0", optional = true }
 bytes = { version = "0.5.0", optional = true }
 bzip2 = { version = "0.3.3" , optional = true }
 flate2 = { version = "1.0.11", optional = true }

--- a/src/codec/brotli/encoder.rs
+++ b/src/codec/brotli/encoder.rs
@@ -1,38 +1,58 @@
 use crate::{codec::Encode, util::PartialBuffer};
-use std::{fmt, io::Result};
+use std::{
+    fmt,
+    io::{Error, ErrorKind, Result},
+};
 
-use brotli2::{
-    raw::{CoStatus, Compress, CompressOp},
-    CompressParams,
+use brotli::enc::{
+    backward_references::BrotliEncoderParams,
+    encode::{
+        BrotliEncoderCompressStream, BrotliEncoderCreateInstance, BrotliEncoderOperation,
+        BrotliEncoderStateStruct,
+    },
+    StandardAlloc,
 };
 
 pub struct BrotliEncoder {
-    compress: Compress,
+    state: BrotliEncoderStateStruct<StandardAlloc>,
 }
 
 impl BrotliEncoder {
-    pub(crate) fn new(params: &CompressParams) -> Self {
-        let mut compress = Compress::new();
-        compress.set_params(params);
-        Self { compress }
+    pub(crate) fn new(params: BrotliEncoderParams) -> Self {
+        let mut state = BrotliEncoderCreateInstance(StandardAlloc::default());
+        state.params = params;
+        Self { state }
     }
 
     fn encode(
         &mut self,
         input: &mut PartialBuffer<&[u8]>,
         output: &mut PartialBuffer<&mut [u8]>,
-        op: CompressOp,
-    ) -> Result<CoStatus> {
-        let mut in_buf = input.unwritten();
+        op: BrotliEncoderOperation,
+    ) -> Result<bool> {
+        let in_buf = input.unwritten();
         let mut out_buf = output.unwritten_mut();
 
-        let original_input_len = in_buf.len();
-        let original_output_len = out_buf.len();
+        let mut input_len = 0;
+        let mut output_len = 0;
 
-        let status = self.compress.compress(op, &mut in_buf, &mut out_buf)?;
-
-        let input_len = original_input_len - in_buf.len();
-        let output_len = original_output_len - out_buf.len();
+        let status = if BrotliEncoderCompressStream(
+            &mut self.state,
+            op,
+            &mut in_buf.len(),
+            in_buf,
+            &mut input_len,
+            &mut out_buf.len(),
+            &mut out_buf,
+            &mut output_len,
+            &mut None,
+            &mut |_, _, _, _| (),
+        ) <= 0
+        {
+            return Err(Error::new(ErrorKind::Other, "brotli error"));
+        } else {
+            self.state.available_out_ == 0
+        };
 
         input.advance(input_len);
         output.advance(output_len);
@@ -47,21 +67,28 @@ impl Encode for BrotliEncoder {
         input: &mut PartialBuffer<&[u8]>,
         output: &mut PartialBuffer<&mut [u8]>,
     ) -> Result<()> {
-        self.encode(input, output, CompressOp::Process).map(drop)
+        self.encode(
+            input,
+            output,
+            BrotliEncoderOperation::BROTLI_OPERATION_PROCESS,
+        )
+        .map(drop)
     }
 
     fn flush(&mut self, output: &mut PartialBuffer<&mut [u8]>) -> Result<bool> {
-        match self.encode(&mut PartialBuffer::new(&[][..]), output, CompressOp::Flush)? {
-            CoStatus::Unfinished => Ok(false),
-            CoStatus::Finished => Ok(true),
-        }
+        Ok(self.encode(
+            &mut PartialBuffer::new(&[][..]),
+            output,
+            BrotliEncoderOperation::BROTLI_OPERATION_FLUSH,
+        )?)
     }
 
     fn finish(&mut self, output: &mut PartialBuffer<&mut [u8]>) -> Result<bool> {
-        match self.encode(&mut PartialBuffer::new(&[][..]), output, CompressOp::Finish)? {
-            CoStatus::Unfinished => Ok(false),
-            CoStatus::Finished => Ok(true),
-        }
+        Ok(self.encode(
+            &mut PartialBuffer::new(&[][..]),
+            output,
+            BrotliEncoderOperation::BROTLI_OPERATION_FINISH,
+        )?)
     }
 }
 

--- a/src/codec/brotli/encoder.rs
+++ b/src/codec/brotli/encoder.rs
@@ -89,7 +89,7 @@ impl Encode for BrotliEncoder {
             BrotliEncoderOperation::BROTLI_OPERATION_FINISH,
         )?;
 
-        Ok(BrotliEncoderIsFinished(&self.state) != 0)
+        Ok(BrotliEncoderIsFinished(&self.state) == 1)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ pub mod flate2 {
     pub use flate2::Compression;
 }
 
-/// Types to configure [`brotli2`](::brotli2) based encoders.
+/// Types to configure [`brotli`](::brotli) based encoders.
 #[cfg(feature = "brotli")]
 #[cfg_attr(docsrs, doc(cfg(feature = "brotli")))]
 pub mod brotli {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,8 +144,8 @@ pub mod flate2 {
 /// Types to configure [`brotli2`](::brotli2) based encoders.
 #[cfg(feature = "brotli")]
 #[cfg_attr(docsrs, doc(cfg(feature = "brotli")))]
-pub mod brotli2 {
-    pub use brotli2::CompressParams;
+pub mod brotli {
+    pub use brotli::enc::backward_references::BrotliEncoderParams;
 }
 
 /// Types to configure [`bzip2`](::bzip2) based encoders.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -23,12 +23,12 @@ macro_rules! algos {
         algos!(@algo brotli ["brotli"] BrotliDecoder BrotliEncoder<$inner> {
             /// The `level` argument here is typically 0-11.
             pub fn new(reader: $inner, level: u32) -> Self {
-                let mut params = brotli2::CompressParams::new();
-                params.quality(level);
-                Self::from_params(reader, &params)
+                let mut params = brotli::enc::backward_references::BrotliEncoderParams::default();
+                params.quality = level as _;
+                Self::from_params(reader, params)
             }
         } {
-            pub fn from_params(inner: $inner, params: &brotli2::CompressParams) -> Self {
+            pub fn from_params(inner: $inner, params: brotli::enc::backward_references::BrotliEncoderParams) -> Self {
                 Self {
                     inner: crate::$($mod::)+generic::Encoder::new(
                         inner,

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -133,13 +133,15 @@ pub mod brotli {
         use crate::utils::prelude::*;
 
         pub fn compress(bytes: &[u8]) -> Vec<u8> {
-            use brotli2::bufread::BrotliEncoder;
-            read_to_vec(BrotliEncoder::new(bytes, 1))
+            use brotli::{enc::backward_references::BrotliEncoderParams, CompressorReader};
+            let mut params = BrotliEncoderParams::default();
+            params.quality = 1;
+            read_to_vec(CompressorReader::with_params(bytes, 0, &params))
         }
 
         pub fn decompress(bytes: &[u8]) -> Vec<u8> {
-            use brotli2::bufread::BrotliDecoder;
-            read_to_vec(BrotliDecoder::new(bytes))
+            use brotli::Decompressor;
+            read_to_vec(Decompressor::new(bytes, 0))
         }
     }
 


### PR DESCRIPTION
Fixes #39.

I removed `brotli2` because it is severely outdated. It uses a version of googles `brotli` that is almost 3 years old.
If requested I can add `brotli2`, but would like to have some guidance on naming the features.