### PR TITLE
RFC: Add Level::Precise to allow precise quality level specification.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,10 @@ pub enum Level {
     Best,
     /// Default quality of compression defined by the selected compression algorithm.
     Default,
+    /// Precise quality based on the underlying compression algorithms'
+    /// qualities. The interpretation of this depends on the algorithm choosen.
+    /// For bzip2, this is treated as default.
+    Precise(u32),
 }
 
 impl Level {
@@ -170,6 +174,7 @@ impl Level {
         match self {
             Self::Fastest => params.quality = 0,
             Self::Best => params.quality = 11,
+            Self::Precise(quality) => params.quality = quality as i32,
             Self::Default => (),
         }
 
@@ -181,6 +186,7 @@ impl Level {
         match self {
             Self::Fastest => bzip2::Compression::Fastest,
             Self::Best => bzip2::Compression::Best,
+            Self::Precise(_) => bzip2::Compression::Default,
             Self::Default => bzip2::Compression::Default,
         }
     }
@@ -190,6 +196,7 @@ impl Level {
         match self {
             Self::Fastest => flate2::Compression::fast(),
             Self::Best => flate2::Compression::best(),
+            Self::Precise(quality) => flate2::Compression::new(quality as u32),
             Self::Default => flate2::Compression::default(),
         }
     }
@@ -199,6 +206,7 @@ impl Level {
         match self {
             Self::Fastest => 1,
             Self::Best => 21,
+            Self::Precise(quality) => quality as i32,
             Self::Default => 0,
         }
     }
@@ -208,6 +216,7 @@ impl Level {
         match self {
             Self::Fastest => 0,
             Self::Best => 9,
+            Self::Precise(quality) => quality,
             Self::Default => 5,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,8 +163,8 @@ pub enum Level {
     /// Default quality of compression defined by the selected compression algorithm.
     Default,
     /// Precise quality based on the underlying compression algorithms'
-    /// qualities. The interpretation of this depends on the algorithm choosen.
-    /// For bzip2, this is treated as default.
+    /// qualities. The interpretation of this depends on the algorithm chosen
+    /// and the specific implementation backing it.
     Precise(u32),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,9 @@ pub enum Level {
     /// Precise quality based on the underlying compression algorithms'
     /// qualities. The interpretation of this depends on the algorithm chosen
     /// and the specific implementation backing it.
+    /// Qualities are implicitly clamped to the algorithm's maximum.
+    ///
+    /// For bzip2, this is treated as default.
     Precise(u32),
 }
 
@@ -174,7 +177,7 @@ impl Level {
         match self {
             Self::Fastest => params.quality = 0,
             Self::Best => params.quality = 11,
-            Self::Precise(quality) => params.quality = quality as i32,
+            Self::Precise(quality) => params.quality = std::cmp::min(quality, 11) as i32,
             Self::Default => (),
         }
 
@@ -206,7 +209,7 @@ impl Level {
         match self {
             Self::Fastest => 1,
             Self::Best => 21,
-            Self::Precise(quality) => quality as i32,
+            Self::Precise(quality) => std::cmp::min(quality, 21) as i32,
             Self::Default => 0,
         }
     }
@@ -216,7 +219,7 @@ impl Level {
         match self {
             Self::Fastest => 0,
             Self::Best => 9,
-            Self::Precise(quality) => quality,
+            Self::Precise(quality) => std::cmp::min(quality, 9),
             Self::Default => 5,
         }
     }


### PR DESCRIPTION
First thanks for making this! We're very happily migrating some sync code to use this within a hyper server.

Since we're using this crate in a high-performance speed and size sensitive web service, we need to tune our underlying algorithm qualities beyond just `Fastest`, `Best` and `Default`. For example, Brotli's default value is the same as best, which is much too slow for us, but `Fastest` is basically a no-op when measuring compression ratios.

This PR exposes a `Level::Precise(u32)` option to allow specific tuning of the underlying encoder's quality; this works for all algorithms except bzip2, where it just uses `Default`. In basic testing it works like a charm.

I was unable to build tests on latest `master`, so I'm not sure how to begin testing.