### PR TITLE
Make Level non-exhaustive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,7 @@ mod util;
 use brotli::enc::backward_references::BrotliEncoderParams;
 
 /// Level of compression data should be compressed with.
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug)]
 pub enum Level {
     /// Fastest quality of compression, usually produces bigger size.


### PR DESCRIPTION
Technically a breaking change (same with #86), but I have verified that all current rev-deps don't try and match on this (and if any do, I'll yank and do a proper breaking release).