### PR TITLE
Add support for tokio v0.2

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,7 @@ jobs:
         toolchain: stable
     - uses: actions-rs/tarpaulin@v0.1
       with:
+        version: 0.13.3  # v0.14.0 has issues with time v0.2.16
         args:
           --locked
           --all-features

--- a/.github/workflows/exhaustive.yml
+++ b/.github/workflows/exhaustive.yml
@@ -46,7 +46,7 @@ jobs:
           --workspace
           --feature-powerset
           --no-dev-deps
-          --skip 'all,all-algorithms,all-implementations'
+          --skip 'all,all-algorithms,all-implementations,futures-bufread,futures-write'
 
   check-test-features:
     name: cargo hack check --all-targets --feature-powerset
@@ -67,7 +67,7 @@ jobs:
           --workspace
           --feature-powerset
           --all-targets
-          --skip 'all,all-algorithms,all-implementations'
+          --skip 'all,all-algorithms,all-implementations,futures-bufread,futures-write'
 
 on:
   push:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.7.3",
  "timebomb",
+ "tokio",
  "xz2",
  "zstd",
  "zstd-safe",
@@ -1047,6 +1048,18 @@ checksum = "7f0886f4b637067027d8c9a038a9249d95648689d1a91009d9abb895625f883a"
 dependencies = [
  "pulse",
  "time 0.2.16",
+]
+
+[[package]]
+name = "tokio"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,15 +19,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 # groups
 default = []
 all = ["all-implementations", "all-algorithms"]
-all-implementations = ["futures-bufread", "futures-write", "stream"]
+all-implementations = ["futures-io", "stream", "tokio-02"]
 all-algorithms = ["brotli", "bzip2", "deflate", "gzip", "lzma", "xz", "zlib", "zstd"]
 
 # implementations
-futures-bufread = ["futures-io"]
-futures-write = ["futures-io"]
 stream = ["bytes"]
-tokio-02-bufread = ["tokio_02"]
-tokio-02-write = ["tokio_02"]
 
 # algorithms
 deflate = ["flate2"]
@@ -36,6 +32,10 @@ lzma = ["xz2"]
 xz = ["xz2"]
 zlib = ["flate2"]
 zstd = ["libzstd", "zstd-safe"]
+
+# deprecated
+futures-bufread = ["futures-io"]
+futures-write = ["futures-io"]
 
 [dependencies]
 xz2 = { version = "0.1.6", optional = true }
@@ -49,7 +49,7 @@ pin-project-lite = "0.1.1"
 libzstd = { package = "zstd", version = "0.5.0", optional = true, default-features = false }
 zstd-safe = { version = "2.0.0", optional = true, default-features = false }
 memchr = "2.2.1"
-tokio_02 = { package = "tokio", version = "0.2.21", optional = true, default-features = false }
+tokio-02 = { package = "tokio", version = "0.2.21", optional = true, default-features = false }
 
 [dev-dependencies]
 proptest = "0.9.4"
@@ -60,7 +60,7 @@ futures-test = "0.3.0"
 ntest = "0.3.3"
 timebomb = "0.1.2"
 bytes = "0.5.0"
-tokio_02 = { package = "tokio", version = "0.2.21", default-features = false, features = ["io-util", "stream"] }
+tokio-02 = { package = "tokio", version = "0.2.21", default-features = false, features = ["io-util", "stream"] }
 
 [[test]]
 name = "brotli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ all-algorithms = ["brotli", "bzip2", "deflate", "gzip", "lzma", "xz", "zlib", "z
 futures-bufread = ["futures-io"]
 futures-write = ["futures-io"]
 stream = ["bytes"]
+tokio-02-bufread = ["tokio_02"]
+tokio-02-write = ["tokio_02"]
 
 # algorithms
 deflate = ["flate2"]
@@ -44,9 +46,10 @@ flate2 = { version = "1.0.11", optional = true }
 futures-core = { version = "0.3.0", default-features = false }
 futures-io = { version = "0.3.0", default-features = false, features = ["std"], optional = true }
 pin-project-lite = "0.1.1"
-libzstd = { version = "0.5.0", optional = true, package = "zstd", default-features = false }
+libzstd = { package = "zstd", version = "0.5.0", optional = true, default-features = false }
 zstd-safe = { version = "2.0.0", optional = true, default-features = false }
 memchr = "2.2.1"
+tokio_02 = { package = "tokio", version = "0.2.21", optional = true, default-features = false }
 
 [dev-dependencies]
 proptest = "0.9.4"
@@ -56,6 +59,8 @@ futures = "0.3.0"
 futures-test = "0.3.0"
 ntest = "0.3.3"
 timebomb = "0.1.2"
+bytes = "0.5.0"
+tokio_02 = { package = "tokio", version = "0.2.21", default-features = false, features = ["io-util", "stream"] }
 
 [[test]]
 name = "brotli"

--- a/src/futures/mod.rs
+++ b/src/futures/mod.rs
@@ -1,9 +1,4 @@
 //! Implementations for IO traits exported by `futures`.
 
-#[cfg(feature = "futures-bufread")]
-#[cfg_attr(docsrs, doc(cfg(feature = "futures-bufread")))]
 pub mod bufread;
-
-#[cfg(feature = "futures-write")]
-#[cfg_attr(docsrs, doc(cfg(feature = "futures-write")))]
 pub mod write;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,20 +30,20 @@
 // TODO: Kill rustfmt on this section, `#![rustfmt::skip::attributes(cfg_attr)]` should do it, but
 // that's unstable
 #![cfg_attr(
-    feature = "futures-bufread",
-    doc = "[`futures-bufread`](crate::futures::bufread) | [`futures::io::AsyncBufRead`](futures_io::AsyncBufRead)"
+    feature = "futures-io",
+    doc = "[`futures-io`](crate::futures) | [`futures::io::AsyncBufRead`](futures_io::AsyncBufRead), [`futures::io::AsyncWrite`](futures_io::AsyncWrite)"
 )]
 #![cfg_attr(
-    not(feature = "futures-bufread"),
-    doc = "`futures-bufread` (*inactive*) | `futures::io::AsyncBufRead`"
+    not(feature = "futures-io"),
+    doc = "`futures-io` (*inactive*) | `futures::io::AsyncBufRead`, `futures::io::AsyncWrite`"
+)]
+#![cfg_attr(
+    feature = "futures-bufread",
+    doc = "`futures-bufread` | (*deprecated*, use `futures-io`)"
 )]
 #![cfg_attr(
     feature = "futures-write",
-    doc = "[`futures-write`](crate::futures::write) | [`futures::io::AsyncWrite`](futures_io::AsyncWrite)"
-)]
-#![cfg_attr(
-    not(feature = "futures-write"),
-    doc = "`futures-write` (*inactive*) | `futures::io::AsyncWrite`"
+    doc = "`futures-write` | (*deprecated*, use `futures-io`)"
 )]
 #![cfg_attr(
     feature = "stream",
@@ -54,20 +54,12 @@
     doc = "`stream` (*inactive*) | `futures::stream::Stream<Item = std::io::Result<bytes::Bytes>>`"
 )]
 #![cfg_attr(
-    feature = "tokio-02-bufread",
-    doc = "[`tokio-02-bufread`](crate::tokio_02::bufread) | [`tokio::io::AsyncBufRead`](::tokio_02::io::AsyncBufRead)"
+    feature = "tokio-02",
+    doc = "[`tokio-02`](crate::tokio_02) | [`tokio::io::AsyncBufRead`](::tokio_02::io::AsyncBufRead), [`tokio::io::AsyncWrite`](::tokio_02::io::AsyncWrite)"
 )]
 #![cfg_attr(
-    not(feature = "tokio-02-bufread"),
-    doc = "`tokio-02-bufread` (*inactive*) | `tokio::io::AsyncBufRead`"
-)]
-#![cfg_attr(
-    feature = "tokio-02-write",
-    doc = "[`tokio-02-write`](crate::tokio_02::write) | [`tokio::io::AsyncWrite`](::tokio_02::io::AsyncWrite)"
-)]
-#![cfg_attr(
-    not(feature = "tokio-02-write"),
-    doc = "`tokio-02-write` (*inactive*) | `tokio::io::AsyncWrite`"
+    not(feature = "tokio-02"),
+    doc = "`tokio-02` (*inactive*) | `tokio::io::AsyncBufRead`, `tokio::io::AsyncWrite`"
 )]
 //!
 
@@ -158,12 +150,14 @@
 mod macros;
 mod codec;
 
-#[cfg(any(feature = "futures-bufread", feature = "futures-write"))]
+#[cfg(feature = "futures-io")]
+#[cfg_attr(docsrs, doc(cfg(feature = "futures-io")))]
 pub mod futures;
 #[cfg(feature = "stream")]
 #[cfg_attr(docsrs, doc(cfg(feature = "stream")))]
 pub mod stream;
-#[cfg(any(feature = "tokio-02-bufread", feature = "tokio-02-write"))]
+#[cfg(feature = "tokio-02")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio-02")))]
 pub mod tokio_02;
 
 mod unshared;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,22 @@
     not(feature = "stream"),
     doc = "`stream` (*inactive*) | `futures::stream::Stream<Item = std::io::Result<bytes::Bytes>>`"
 )]
+#![cfg_attr(
+    feature = "tokio-02-bufread",
+    doc = "[`tokio-02-bufread`](crate::tokio_02::bufread) | [`tokio::io::AsyncBufRead`](::tokio_02::io::AsyncBufRead)"
+)]
+#![cfg_attr(
+    not(feature = "tokio-02-bufread"),
+    doc = "`tokio-02-bufread` (*inactive*) | `tokio::io::AsyncBufRead`"
+)]
+#![cfg_attr(
+    feature = "tokio-02-write",
+    doc = "[`tokio-02-write`](crate::tokio_02::write) | [`tokio::io::AsyncWrite`](::tokio_02::io::AsyncWrite)"
+)]
+#![cfg_attr(
+    not(feature = "tokio-02-write"),
+    doc = "`tokio-02-write` (*inactive*) | `tokio::io::AsyncWrite`"
+)]
 //!
 
 //! ## Compression algorithm
@@ -147,6 +163,8 @@ pub mod futures;
 #[cfg(feature = "stream")]
 #[cfg_attr(docsrs, doc(cfg(feature = "stream")))]
 pub mod stream;
+#[cfg(any(feature = "tokio-02-bufread", feature = "tokio-02-write"))]
+pub mod tokio_02;
 
 mod unshared;
 mod util;

--- a/src/tokio_02/bufread/generic/decoder.rs
+++ b/src/tokio_02/bufread/generic/decoder.rs
@@ -1,0 +1,138 @@
+use core::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use std::io::Result;
+
+use crate::{codec::Decode, util::PartialBuffer};
+use futures_core::ready;
+use pin_project_lite::pin_project;
+use tokio_02::io::{AsyncBufRead, AsyncRead};
+
+#[derive(Debug)]
+enum State {
+    Decoding,
+    Flushing,
+    Done,
+    Next,
+}
+
+pin_project! {
+    #[derive(Debug)]
+    pub struct Decoder<R, D: Decode> {
+        #[pin]
+        reader: R,
+        decoder: D,
+        state: State,
+        multiple_members: bool,
+    }
+}
+
+impl<R: AsyncBufRead, D: Decode> Decoder<R, D> {
+    pub fn new(reader: R, decoder: D) -> Self {
+        Self {
+            reader,
+            decoder,
+            state: State::Decoding,
+            multiple_members: false,
+        }
+    }
+
+    pub fn get_ref(&self) -> &R {
+        &self.reader
+    }
+
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.reader
+    }
+
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut R> {
+        self.project().reader
+    }
+
+    pub fn into_inner(self) -> R {
+        self.reader
+    }
+
+    pub fn multiple_members(&mut self, enabled: bool) {
+        self.multiple_members = enabled;
+    }
+
+    fn do_poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut PartialBuffer<&mut [u8]>,
+    ) -> Poll<Result<()>> {
+        let mut this = self.project();
+
+        loop {
+            *this.state = match this.state {
+                State::Decoding => {
+                    let input = ready!(this.reader.as_mut().poll_fill_buf(cx))?;
+                    if input.is_empty() {
+                        State::Flushing
+                    } else {
+                        let mut input = PartialBuffer::new(input);
+                        let done = this.decoder.decode(&mut input, output)?;
+                        let len = input.written().len();
+                        this.reader.as_mut().consume(len);
+                        if done {
+                            State::Flushing
+                        } else {
+                            State::Decoding
+                        }
+                    }
+                }
+
+                State::Flushing => {
+                    if this.decoder.finish(output)? {
+                        if *this.multiple_members {
+                            this.decoder.reinit()?;
+                            State::Next
+                        } else {
+                            State::Done
+                        }
+                    } else {
+                        State::Flushing
+                    }
+                }
+
+                State::Done => State::Done,
+
+                State::Next => {
+                    let input = ready!(this.reader.as_mut().poll_fill_buf(cx))?;
+                    if input.is_empty() {
+                        State::Done
+                    } else {
+                        State::Decoding
+                    }
+                }
+            };
+
+            if let State::Done = *this.state {
+                return Poll::Ready(Ok(()));
+            }
+            if output.unwritten().is_empty() {
+                return Poll::Ready(Ok(()));
+            }
+        }
+    }
+}
+
+impl<R: AsyncBufRead, D: Decode> AsyncRead for Decoder<R, D> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<Result<usize>> {
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
+        let mut output = PartialBuffer::new(buf);
+        match self.do_poll_read(cx, &mut output)? {
+            Poll::Pending if output.written().is_empty() => Poll::Pending,
+            _ => Poll::Ready(Ok(output.written().len())),
+        }
+    }
+}

--- a/src/tokio_02/bufread/generic/encoder.rs
+++ b/src/tokio_02/bufread/generic/encoder.rs
@@ -1,0 +1,113 @@
+use core::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use std::io::Result;
+
+use crate::{codec::Encode, util::PartialBuffer};
+use futures_core::ready;
+use pin_project_lite::pin_project;
+use tokio_02::io::{AsyncBufRead, AsyncRead};
+
+#[derive(Debug)]
+enum State {
+    Encoding,
+    Flushing,
+    Done,
+}
+
+pin_project! {
+    #[derive(Debug)]
+    pub struct Encoder<R, E: Encode> {
+        #[pin]
+        reader: R,
+        encoder: E,
+        state: State,
+    }
+}
+
+impl<R: AsyncBufRead, E: Encode> Encoder<R, E> {
+    pub fn new(reader: R, encoder: E) -> Self {
+        Self {
+            reader,
+            encoder,
+            state: State::Encoding,
+        }
+    }
+
+    pub fn get_ref(&self) -> &R {
+        &self.reader
+    }
+
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.reader
+    }
+
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut R> {
+        self.project().reader
+    }
+
+    pub fn into_inner(self) -> R {
+        self.reader
+    }
+
+    fn do_poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut PartialBuffer<&mut [u8]>,
+    ) -> Poll<Result<()>> {
+        let mut this = self.project();
+
+        loop {
+            *this.state = match this.state {
+                State::Encoding => {
+                    let input = ready!(this.reader.as_mut().poll_fill_buf(cx))?;
+                    if input.is_empty() {
+                        State::Flushing
+                    } else {
+                        let mut input = PartialBuffer::new(input);
+                        this.encoder.encode(&mut input, output)?;
+                        let len = input.written().len();
+                        this.reader.as_mut().consume(len);
+                        State::Encoding
+                    }
+                }
+
+                State::Flushing => {
+                    if this.encoder.finish(output)? {
+                        State::Done
+                    } else {
+                        State::Flushing
+                    }
+                }
+
+                State::Done => State::Done,
+            };
+
+            if let State::Done = *this.state {
+                return Poll::Ready(Ok(()));
+            }
+            if output.unwritten().is_empty() {
+                return Poll::Ready(Ok(()));
+            }
+        }
+    }
+}
+
+impl<R: AsyncBufRead, E: Encode> AsyncRead for Encoder<R, E> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<Result<usize>> {
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
+        let mut output = PartialBuffer::new(buf);
+        match self.do_poll_read(cx, &mut output)? {
+            Poll::Pending if output.written().is_empty() => Poll::Pending,
+            _ => Poll::Ready(Ok(output.written().len())),
+        }
+    }
+}

--- a/src/tokio_02/bufread/generic/mod.rs
+++ b/src/tokio_02/bufread/generic/mod.rs
@@ -1,0 +1,4 @@
+mod decoder;
+mod encoder;
+
+pub use self::{decoder::Decoder, encoder::Encoder};

--- a/src/tokio_02/bufread/macros/decoder.rs
+++ b/src/tokio_02/bufread/macros/decoder.rs
@@ -1,0 +1,84 @@
+macro_rules! decoder {
+    ($(#[$attr:meta])* $name:ident) => {
+        pin_project_lite::pin_project! {
+            $(#[$attr])*
+            #[derive(Debug)]
+            ///
+            /// This structure implements an [`AsyncRead`](tokio_02::io::AsyncRead) interface and will
+            /// read compressed data from an underlying stream and emit a stream of uncompressed data.
+            pub struct $name<R> {
+                #[pin]
+                inner: crate::tokio_02::bufread::Decoder<R, crate::codec::$name>,
+            }
+        }
+
+        impl<R: tokio_02::io::AsyncBufRead> $name<R> {
+            /// Creates a new decoder which will read compressed data from the given stream and
+            /// emit a uncompressed stream.
+            pub fn new(read: R) -> $name<R> {
+                $name {
+                    inner: crate::tokio_02::bufread::Decoder::new(read, crate::codec::$name::new()),
+                }
+            }
+
+            /// Configure multi-member/frame decoding, if enabled this will reset the decoder state
+            /// when reaching the end of a compressed member/frame and expect either EOF or another
+            /// compressed member/frame to follow it in the stream.
+            pub fn multiple_members(&mut self, enabled: bool) {
+                self.inner.multiple_members(enabled);
+            }
+
+            /// Acquires a reference to the underlying reader that this decoder is wrapping.
+            pub fn get_ref(&self) -> &R {
+                self.inner.get_ref()
+            }
+
+            /// Acquires a mutable reference to the underlying reader that this decoder is
+            /// wrapping.
+            ///
+            /// Note that care must be taken to avoid tampering with the state of the reader which
+            /// may otherwise confuse this decoder.
+            pub fn get_mut(&mut self) -> &mut R {
+                self.inner.get_mut()
+            }
+
+            /// Acquires a pinned mutable reference to the underlying reader that this decoder is
+            /// wrapping.
+            ///
+            /// Note that care must be taken to avoid tampering with the state of the reader which
+            /// may otherwise confuse this decoder.
+            pub fn get_pin_mut(self: std::pin::Pin<&mut Self>) -> std::pin::Pin<&mut R> {
+                self.project().inner.get_pin_mut()
+            }
+
+            /// Consumes this decoder returning the underlying reader.
+            ///
+            /// Note that this may discard internal state of this decoder, so care should be taken
+            /// to avoid losing resources when this is called.
+            pub fn into_inner(self) -> R {
+                self.inner.into_inner()
+            }
+        }
+
+        impl<R: tokio_02::io::AsyncBufRead> tokio_02::io::AsyncRead for $name<R> {
+            fn poll_read(
+                self: std::pin::Pin<&mut Self>,
+                cx: &mut std::task::Context<'_>,
+                buf: &mut [u8],
+            ) -> std::task::Poll<std::io::Result<usize>> {
+                self.project().inner.poll_read(cx, buf)
+            }
+        }
+
+        const _: () = {
+            fn _assert() {
+                use crate::util::{_assert_send, _assert_sync};
+                use core::pin::Pin;
+                use tokio_02::io::AsyncBufRead;
+
+                _assert_send::<$name<Pin<Box<dyn AsyncBufRead + Send>>>>();
+                _assert_sync::<$name<Pin<Box<dyn AsyncBufRead + Sync>>>>();
+            }
+        };
+    }
+}

--- a/src/tokio_02/bufread/macros/encoder.rs
+++ b/src/tokio_02/bufread/macros/encoder.rs
@@ -1,0 +1,76 @@
+macro_rules! encoder {
+    ($(#[$attr:meta])* $name:ident<$inner:ident> $({ $($constructor:tt)* })*) => {
+        pin_project_lite::pin_project! {
+            $(#[$attr])*
+            #[derive(Debug)]
+            ///
+            /// This structure implements an [`AsyncRead`](tokio_02::io::AsyncRead) interface and will
+            /// read uncompressed data from an underlying stream and emit a stream of compressed data.
+            pub struct $name<$inner> {
+                #[pin]
+                inner: crate::tokio_02::bufread::Encoder<$inner, crate::codec::$name>,
+            }
+        }
+
+        impl<$inner: tokio_02::io::AsyncBufRead> $name<$inner> {
+            $(
+                /// Creates a new encoder which will read uncompressed data from the given stream
+                /// and emit a compressed stream.
+                ///
+                $($constructor)*
+            )*
+
+            /// Acquires a reference to the underlying reader that this encoder is wrapping.
+            pub fn get_ref(&self) -> &$inner {
+                self.inner.get_ref()
+            }
+
+            /// Acquires a mutable reference to the underlying reader that this encoder is
+            /// wrapping.
+            ///
+            /// Note that care must be taken to avoid tampering with the state of the reader which
+            /// may otherwise confuse this encoder.
+            pub fn get_mut(&mut self) -> &mut $inner {
+                self.inner.get_mut()
+            }
+
+            /// Acquires a pinned mutable reference to the underlying reader that this encoder is
+            /// wrapping.
+            ///
+            /// Note that care must be taken to avoid tampering with the state of the reader which
+            /// may otherwise confuse this encoder.
+            pub fn get_pin_mut(self: std::pin::Pin<&mut Self>) -> std::pin::Pin<&mut $inner> {
+                self.project().inner.get_pin_mut()
+            }
+
+            /// Consumes this encoder returning the underlying reader.
+            ///
+            /// Note that this may discard internal state of this encoder, so care should be taken
+            /// to avoid losing resources when this is called.
+            pub fn into_inner(self) -> $inner {
+                self.inner.into_inner()
+            }
+        }
+
+        impl<$inner: tokio_02::io::AsyncBufRead> tokio_02::io::AsyncRead for $name<$inner> {
+            fn poll_read(
+                self: std::pin::Pin<&mut Self>,
+                cx: &mut std::task::Context<'_>,
+                buf: &mut [u8],
+            ) -> std::task::Poll<std::io::Result<usize>> {
+                self.project().inner.poll_read(cx, buf)
+            }
+        }
+
+        const _: () = {
+            fn _assert() {
+                use crate::util::{_assert_send, _assert_sync};
+                use core::pin::Pin;
+                use tokio_02::io::AsyncBufRead;
+
+                _assert_send::<$name<Pin<Box<dyn AsyncBufRead + Send>>>>();
+                _assert_sync::<$name<Pin<Box<dyn AsyncBufRead + Sync>>>>();
+            }
+        };
+    }
+}

--- a/src/tokio_02/bufread/macros/mod.rs
+++ b/src/tokio_02/bufread/macros/mod.rs
@@ -1,0 +1,4 @@
+#[macro_use]
+mod decoder;
+#[macro_use]
+mod encoder;

--- a/src/tokio_02/bufread/mod.rs
+++ b/src/tokio_02/bufread/mod.rs
@@ -1,0 +1,10 @@
+//! Types which operate over [`AsyncBufRead`](::tokio_02::io::AsyncBufRead) streams, both encoders and
+//! decoders for various formats.
+
+#[macro_use]
+mod macros;
+mod generic;
+
+pub(crate) use generic::{Decoder, Encoder};
+
+algos!(tokio_02::bufread<R>);

--- a/src/tokio_02/mod.rs
+++ b/src/tokio_02/mod.rs
@@ -1,0 +1,9 @@
+//! Implementations for IO traits exported by [`tokio` v0.2](::tokio_02).
+
+#[cfg(feature = "tokio-02-bufread")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio-02-bufread")))]
+pub mod bufread;
+
+#[cfg(feature = "tokio-02-write")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio-02-write")))]
+pub mod write;

--- a/src/tokio_02/mod.rs
+++ b/src/tokio_02/mod.rs
@@ -1,9 +1,4 @@
 //! Implementations for IO traits exported by [`tokio` v0.2](::tokio_02).
 
-#[cfg(feature = "tokio-02-bufread")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio-02-bufread")))]
 pub mod bufread;
-
-#[cfg(feature = "tokio-02-write")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio-02-write")))]
 pub mod write;

--- a/src/tokio_02/write/buf_write.rs
+++ b/src/tokio_02/write/buf_write.rs
@@ -1,0 +1,32 @@
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+pub(crate) trait AsyncBufWrite {
+    /// Attempt to return an internal buffer to write to, flushing data out to the inner reader if
+    /// it is full.
+    ///
+    /// On success, returns `Poll::Ready(Ok(buf))`.
+    ///
+    /// If the buffer is full and cannot be flushed, the method returns `Poll::Pending` and
+    /// arranges for the current task context (`cx`) to receive a notification when the object
+    /// becomes readable or is closed.
+    fn poll_partial_flush_buf(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<&mut [u8]>>;
+
+    /// Tells this buffer that `amt` bytes have been written to its buffer, so they should be
+    /// written out to the underlying IO when possible.
+    ///
+    /// This function is a lower-level call. It needs to be paired with the `poll_flush_buf` method to
+    /// function properly. This function does not perform any I/O, it simply informs this object
+    /// that some amount of its buffer, returned from `poll_flush_buf`, has been written to and should
+    /// be sent. As such, this function may do odd things if `poll_flush_buf` isn't
+    /// called before calling it.
+    ///
+    /// The `amt` must be `<=` the number of bytes in the buffer returned by `poll_flush_buf`.
+    fn produce(self: Pin<&mut Self>, amt: usize);
+}

--- a/src/tokio_02/write/buf_writer.rs
+++ b/src/tokio_02/write/buf_writer.rs
@@ -1,0 +1,209 @@
+// Originally sourced from `futures_util::io::buf_writer`, needs to be redefined locally so that
+// the `AsyncBufWrite` impl can access its internals, and changed a bit to make it more efficient
+// with those methods.
+
+use super::AsyncBufWrite;
+use futures_core::ready;
+use pin_project_lite::pin_project;
+use std::{
+    cmp::min,
+    fmt, io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio_02::io::AsyncWrite;
+
+const DEFAULT_BUF_SIZE: usize = 8192;
+
+pin_project! {
+    pub struct BufWriter<W> {
+        #[pin]
+        inner: W,
+        buf: Box<[u8]>,
+        written: usize,
+        buffered: usize,
+    }
+}
+
+impl<W: AsyncWrite> BufWriter<W> {
+    /// Creates a new `BufWriter` with a default buffer capacity. The default is currently 8 KB,
+    /// but may change in the future.
+    pub fn new(inner: W) -> Self {
+        Self::with_capacity(DEFAULT_BUF_SIZE, inner)
+    }
+
+    /// Creates a new `BufWriter` with the specified buffer capacity.
+    pub fn with_capacity(cap: usize, inner: W) -> Self {
+        Self {
+            inner,
+            buf: vec![0; cap].into(),
+            written: 0,
+            buffered: 0,
+        }
+    }
+
+    fn partial_flush_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let mut this = self.project();
+
+        let mut ret = Ok(());
+        while *this.written < *this.buffered {
+            match this
+                .inner
+                .as_mut()
+                .poll_write(cx, &this.buf[*this.written..*this.buffered])
+            {
+                Poll::Pending => {
+                    break;
+                }
+                Poll::Ready(Ok(0)) => {
+                    ret = Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "failed to write the buffered data",
+                    ));
+                    break;
+                }
+                Poll::Ready(Ok(n)) => *this.written += n,
+                Poll::Ready(Err(e)) => {
+                    ret = Err(e);
+                    break;
+                }
+            }
+        }
+
+        if *this.written > 0 {
+            this.buf.copy_within(*this.written..*this.buffered, 0);
+            *this.buffered -= *this.written;
+            *this.written = 0;
+
+            Poll::Ready(ret)
+        } else if *this.buffered == 0 {
+            Poll::Ready(ret)
+        } else {
+            ret?;
+            Poll::Pending
+        }
+    }
+
+    fn flush_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let mut this = self.project();
+
+        let mut ret = Ok(());
+        while *this.written < *this.buffered {
+            match ready!(this
+                .inner
+                .as_mut()
+                .poll_write(cx, &this.buf[*this.written..*this.buffered]))
+            {
+                Ok(0) => {
+                    ret = Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "failed to write the buffered data",
+                    ));
+                    break;
+                }
+                Ok(n) => *this.written += n,
+                Err(e) => {
+                    ret = Err(e);
+                    break;
+                }
+            }
+        }
+        this.buf.copy_within(*this.written..*this.buffered, 0);
+        *this.buffered -= *this.written;
+        *this.written = 0;
+        Poll::Ready(ret)
+    }
+
+    /// Gets a reference to the underlying writer.
+    pub fn get_ref(&self) -> &W {
+        &self.inner
+    }
+
+    /// Gets a mutable reference to the underlying writer.
+    ///
+    /// It is inadvisable to directly write to the underlying writer.
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.inner
+    }
+
+    /// Gets a pinned mutable reference to the underlying writer.
+    ///
+    /// It is inadvisable to directly write to the underlying writer.
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut W> {
+        self.project().inner
+    }
+
+    /// Consumes this `BufWriter`, returning the underlying writer.
+    ///
+    /// Note that any leftover data in the internal buffer is lost.
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
+}
+
+impl<W: AsyncWrite> AsyncWrite for BufWriter<W> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.as_mut().project();
+        if *this.buffered + buf.len() > this.buf.len() {
+            ready!(self.as_mut().partial_flush_buf(cx))?;
+        }
+
+        let this = self.as_mut().project();
+        if buf.len() >= this.buf.len() {
+            if *this.buffered == 0 {
+                this.inner.poll_write(cx, buf)
+            } else {
+                // The only way that `partial_flush_buf` would have returned with
+                // `this.buffered != 0` is if it were Pending, so our waker was already queued
+                Poll::Pending
+            }
+        } else {
+            let len = min(this.buf.len() - *this.buffered, buf.len());
+            this.buf[*this.buffered..*this.buffered + len].copy_from_slice(&buf[..len]);
+            *this.buffered += len;
+            Poll::Ready(Ok(len))
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        ready!(self.as_mut().flush_buf(cx))?;
+        self.project().inner.poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        ready!(self.as_mut().flush_buf(cx))?;
+        self.project().inner.poll_shutdown(cx)
+    }
+}
+
+impl<W: AsyncWrite> AsyncBufWrite for BufWriter<W> {
+    fn poll_partial_flush_buf(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<&mut [u8]>> {
+        ready!(self.as_mut().partial_flush_buf(cx))?;
+        let this = self.project();
+        Poll::Ready(Ok(&mut this.buf[*this.buffered..]))
+    }
+
+    fn produce(self: Pin<&mut Self>, amt: usize) {
+        *self.project().buffered += amt;
+    }
+}
+
+impl<W: fmt::Debug> fmt::Debug for BufWriter<W> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BufWriter")
+            .field("writer", &self.inner)
+            .field(
+                "buffer",
+                &format_args!("{}/{}", self.buffered, self.buf.len()),
+            )
+            .field("written", &self.written)
+            .finish()
+    }
+}

--- a/src/tokio_02/write/generic/decoder.rs
+++ b/src/tokio_02/write/generic/decoder.rs
@@ -1,0 +1,175 @@
+use core::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use std::io::{Error, ErrorKind, Result};
+
+use crate::{
+    codec::Decode,
+    tokio_02::write::{AsyncBufWrite, BufWriter},
+    util::PartialBuffer,
+};
+use futures_core::ready;
+use pin_project_lite::pin_project;
+use tokio_02::io::AsyncWrite;
+
+#[derive(Debug)]
+enum State {
+    Decoding,
+    Finishing,
+    Done,
+}
+
+pin_project! {
+    #[derive(Debug)]
+    pub struct Decoder<W, D: Decode> {
+        #[pin]
+        writer: BufWriter<W>,
+        decoder: D,
+        state: State,
+    }
+}
+
+impl<W: AsyncWrite, D: Decode> Decoder<W, D> {
+    pub fn new(writer: W, decoder: D) -> Self {
+        Self {
+            writer: BufWriter::new(writer),
+            decoder,
+            state: State::Decoding,
+        }
+    }
+
+    pub fn get_ref(&self) -> &W {
+        self.writer.get_ref()
+    }
+
+    pub fn get_mut(&mut self) -> &mut W {
+        self.writer.get_mut()
+    }
+
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut W> {
+        self.project().writer.get_pin_mut()
+    }
+
+    pub fn into_inner(self) -> W {
+        self.writer.into_inner()
+    }
+
+    fn do_poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        input: &mut PartialBuffer<&[u8]>,
+    ) -> Poll<Result<()>> {
+        let mut this = self.project();
+
+        loop {
+            let output = ready!(this.writer.as_mut().poll_partial_flush_buf(cx))?;
+            let mut output = PartialBuffer::new(output);
+
+            *this.state = match this.state {
+                State::Decoding => {
+                    if this.decoder.decode(input, &mut output)? {
+                        State::Finishing
+                    } else {
+                        State::Decoding
+                    }
+                }
+
+                State::Finishing => {
+                    if this.decoder.finish(&mut output)? {
+                        State::Done
+                    } else {
+                        State::Finishing
+                    }
+                }
+
+                State::Done => panic!("Write after end of stream"),
+            };
+
+            let produced = output.written().len();
+            this.writer.as_mut().produce(produced);
+
+            if let State::Done = this.state {
+                return Poll::Ready(Ok(()));
+            }
+
+            if input.unwritten().is_empty() {
+                return Poll::Ready(Ok(()));
+            }
+        }
+    }
+
+    fn do_poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        let mut this = self.project();
+
+        loop {
+            let output = ready!(this.writer.as_mut().poll_partial_flush_buf(cx))?;
+            let mut output = PartialBuffer::new(output);
+
+            let (state, done) = match this.state {
+                State::Decoding => {
+                    let done = this.decoder.flush(&mut output)?;
+                    (State::Decoding, done)
+                }
+
+                State::Finishing => {
+                    if this.decoder.finish(&mut output)? {
+                        (State::Done, false)
+                    } else {
+                        (State::Finishing, false)
+                    }
+                }
+
+                State::Done => (State::Done, true),
+            };
+
+            *this.state = state;
+
+            let produced = output.written().len();
+            this.writer.as_mut().produce(produced);
+
+            if done {
+                return Poll::Ready(Ok(()));
+            }
+        }
+    }
+}
+
+impl<W: AsyncWrite, D: Decode> AsyncWrite for Decoder<W, D> {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
+        let mut input = PartialBuffer::new(buf);
+
+        match self.do_poll_write(cx, &mut input)? {
+            Poll::Pending if input.written().is_empty() => Poll::Pending,
+            _ => Poll::Ready(Ok(input.written().len())),
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        ready!(self.as_mut().do_poll_flush(cx))?;
+        ready!(self.project().writer.as_mut().poll_flush(cx))?;
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        if let State::Decoding = self.as_mut().project().state {
+            *self.as_mut().project().state = State::Finishing;
+        }
+
+        ready!(self.as_mut().do_poll_flush(cx))?;
+
+        if let State::Done = self.as_mut().project().state {
+            ready!(self.as_mut().project().writer.as_mut().poll_shutdown(cx))?;
+            Poll::Ready(Ok(()))
+        } else {
+            Poll::Ready(Err(Error::new(
+                ErrorKind::Other,
+                "Attempt to shutdown before finishing input",
+            )))
+        }
+    }
+}

--- a/src/tokio_02/write/generic/encoder.rs
+++ b/src/tokio_02/write/generic/encoder.rs
@@ -1,0 +1,163 @@
+use core::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use std::io::Result;
+
+use crate::{
+    codec::Encode,
+    tokio_02::write::{AsyncBufWrite, BufWriter},
+    util::PartialBuffer,
+};
+use futures_core::ready;
+use pin_project_lite::pin_project;
+use tokio_02::io::AsyncWrite;
+
+#[derive(Debug)]
+enum State {
+    Encoding,
+    Finishing,
+    Done,
+}
+
+pin_project! {
+    #[derive(Debug)]
+    pub struct Encoder<W, E: Encode> {
+        #[pin]
+        writer: BufWriter<W>,
+        encoder: E,
+        state: State,
+    }
+}
+
+impl<W: AsyncWrite, E: Encode> Encoder<W, E> {
+    pub fn new(writer: W, encoder: E) -> Self {
+        Self {
+            writer: BufWriter::new(writer),
+            encoder,
+            state: State::Encoding,
+        }
+    }
+
+    pub fn get_ref(&self) -> &W {
+        self.writer.get_ref()
+    }
+
+    pub fn get_mut(&mut self) -> &mut W {
+        self.writer.get_mut()
+    }
+
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut W> {
+        self.project().writer.get_pin_mut()
+    }
+
+    pub fn into_inner(self) -> W {
+        self.writer.into_inner()
+    }
+
+    fn do_poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        input: &mut PartialBuffer<&[u8]>,
+    ) -> Poll<Result<()>> {
+        let mut this = self.project();
+
+        loop {
+            let output = ready!(this.writer.as_mut().poll_partial_flush_buf(cx))?;
+            let mut output = PartialBuffer::new(output);
+
+            *this.state = match this.state {
+                State::Encoding => {
+                    this.encoder.encode(input, &mut output)?;
+                    State::Encoding
+                }
+
+                State::Finishing | State::Done => panic!("Write after shutdown"),
+            };
+
+            let produced = output.written().len();
+            this.writer.as_mut().produce(produced);
+
+            if input.unwritten().is_empty() {
+                return Poll::Ready(Ok(()));
+            }
+        }
+    }
+
+    fn do_poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        let mut this = self.project();
+
+        loop {
+            let output = ready!(this.writer.as_mut().poll_partial_flush_buf(cx))?;
+            let mut output = PartialBuffer::new(output);
+
+            let done = match this.state {
+                State::Encoding => this.encoder.flush(&mut output)?,
+
+                State::Finishing | State::Done => panic!("Flush after shutdown"),
+            };
+
+            let produced = output.written().len();
+            this.writer.as_mut().produce(produced);
+
+            if done {
+                return Poll::Ready(Ok(()));
+            }
+        }
+    }
+
+    fn do_poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        let mut this = self.project();
+
+        loop {
+            let output = ready!(this.writer.as_mut().poll_partial_flush_buf(cx))?;
+            let mut output = PartialBuffer::new(output);
+
+            *this.state = match this.state {
+                State::Encoding | State::Finishing => {
+                    if this.encoder.finish(&mut output)? {
+                        State::Done
+                    } else {
+                        State::Finishing
+                    }
+                }
+
+                State::Done => State::Done,
+            };
+
+            let produced = output.written().len();
+            this.writer.as_mut().produce(produced);
+
+            if let State::Done = this.state {
+                return Poll::Ready(Ok(()));
+            }
+        }
+    }
+}
+
+impl<W: AsyncWrite, E: Encode> AsyncWrite for Encoder<W, E> {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
+        let mut input = PartialBuffer::new(buf);
+
+        match self.do_poll_write(cx, &mut input)? {
+            Poll::Pending if input.written().is_empty() => Poll::Pending,
+            _ => Poll::Ready(Ok(input.written().len())),
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        ready!(self.as_mut().do_poll_flush(cx))?;
+        ready!(self.project().writer.as_mut().poll_flush(cx))?;
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        ready!(self.as_mut().do_poll_shutdown(cx))?;
+        ready!(self.project().writer.as_mut().poll_shutdown(cx))?;
+        Poll::Ready(Ok(()))
+    }
+}

--- a/src/tokio_02/write/generic/mod.rs
+++ b/src/tokio_02/write/generic/mod.rs
@@ -1,0 +1,4 @@
+mod decoder;
+mod encoder;
+
+pub use self::{decoder::Decoder, encoder::Encoder};

--- a/src/tokio_02/write/macros/decoder.rs
+++ b/src/tokio_02/write/macros/decoder.rs
@@ -1,0 +1,91 @@
+macro_rules! decoder {
+    ($(#[$attr:meta])* $name:ident) => {
+        pin_project_lite::pin_project! {
+            $(#[$attr])*
+            #[derive(Debug)]
+            ///
+            /// This structure implements an [`AsyncWrite`](tokio_02::io::AsyncWrite) interface and will
+            /// take in compressed data and write it uncompressed to an underlying stream.
+            pub struct $name<W> {
+                #[pin]
+                inner: crate::tokio_02::write::Decoder<W, crate::codec::$name>,
+            }
+        }
+
+        impl<W: tokio_02::io::AsyncWrite> $name<W> {
+            /// Creates a new decoder which will take in compressed data and write it uncompressedd
+            /// to the given stream.
+            pub fn new(read: W) -> $name<W> {
+                $name {
+                    inner: crate::tokio_02::write::Decoder::new(read, crate::codec::$name::new()),
+                }
+            }
+
+            /// Acquires a reference to the underlying reader that this decoder is wrapping.
+            pub fn get_ref(&self) -> &W {
+                self.inner.get_ref()
+            }
+
+            /// Acquires a mutable reference to the underlying reader that this decoder is
+            /// wrapping.
+            ///
+            /// Note that care must be taken to avoid tampering with the state of the reader which
+            /// may otherwise confuse this decoder.
+            pub fn get_mut(&mut self) -> &mut W {
+                self.inner.get_mut()
+            }
+
+            /// Acquires a pinned mutable reference to the underlying reader that this decoder is
+            /// wrapping.
+            ///
+            /// Note that care must be taken to avoid tampering with the state of the reader which
+            /// may otherwise confuse this decoder.
+            pub fn get_pin_mut(self: std::pin::Pin<&mut Self>) -> std::pin::Pin<&mut W> {
+                self.project().inner.get_pin_mut()
+            }
+
+            /// Consumes this decoder returning the underlying reader.
+            ///
+            /// Note that this may discard internal state of this decoder, so care should be taken
+            /// to avoid losing resources when this is called.
+            pub fn into_inner(self) -> W {
+                self.inner.into_inner()
+            }
+        }
+
+        impl<W: tokio_02::io::AsyncWrite> tokio_02::io::AsyncWrite for $name<W> {
+            fn poll_write(
+                self: std::pin::Pin<&mut Self>,
+                cx: &mut std::task::Context<'_>,
+                buf: &[u8],
+            ) -> std::task::Poll<std::io::Result<usize>> {
+                self.project().inner.poll_write(cx, buf)
+            }
+
+            fn poll_flush(
+                self: std::pin::Pin<&mut Self>,
+                cx: &mut std::task::Context<'_>,
+            ) -> std::task::Poll<std::io::Result<()>> {
+                self.project().inner.poll_flush(cx)
+            }
+
+            fn poll_shutdown(
+                self: std::pin::Pin<&mut Self>,
+                cx: &mut std::task::Context<'_>,
+            ) -> std::task::Poll<std::io::Result<()>> {
+                self.project().inner.poll_shutdown(cx)
+            }
+        }
+
+        const _: () = {
+            fn _assert() {
+                use crate::util::{_assert_send, _assert_sync};
+                use core::pin::Pin;
+                use tokio_02::io::AsyncWrite;
+
+                _assert_send::<$name<Pin<Box<dyn AsyncWrite + Send>>>>();
+                _assert_sync::<$name<Pin<Box<dyn AsyncWrite + Sync>>>>();
+            }
+        };
+    }
+}

--- a/src/tokio_02/write/macros/encoder.rs
+++ b/src/tokio_02/write/macros/encoder.rs
@@ -1,0 +1,90 @@
+macro_rules! encoder {
+    ($(#[$attr:meta])* $name:ident<$inner:ident> $({ $($constructor:tt)* })*) => {
+        pin_project_lite::pin_project! {
+            $(#[$attr])*
+            #[derive(Debug)]
+            ///
+            /// This structure implements an [`AsyncWrite`](tokio_02::io::AsyncWrite) interface and will
+            /// take in uncompressed data and write it compressed to an underlying stream.
+            pub struct $name<$inner> {
+                #[pin]
+                inner: crate::tokio_02::write::Encoder<$inner, crate::codec::$name>,
+            }
+        }
+
+        impl<$inner: tokio_02::io::AsyncWrite> $name<$inner> {
+            $(
+                /// Creates a new encoder which will take in uncompressed data and write it
+                /// compressed to the given stream.
+                ///
+                $($constructor)*
+            )*
+
+            /// Acquires a reference to the underlying writer that this encoder is wrapping.
+            pub fn get_ref(&self) -> &$inner {
+                self.inner.get_ref()
+            }
+
+            /// Acquires a mutable reference to the underlying writer that this encoder is
+            /// wrapping.
+            ///
+            /// Note that care must be taken to avoid tampering with the state of the writer which
+            /// may otherwise confuse this encoder.
+            pub fn get_mut(&mut self) -> &mut $inner {
+                self.inner.get_mut()
+            }
+
+            /// Acquires a pinned mutable reference to the underlying writer that this encoder is
+            /// wrapping.
+            ///
+            /// Note that care must be taken to avoid tampering with the state of the writer which
+            /// may otherwise confuse this encoder.
+            pub fn get_pin_mut(self: std::pin::Pin<&mut Self>) -> std::pin::Pin<&mut $inner> {
+                self.project().inner.get_pin_mut()
+            }
+
+            /// Consumes this encoder returning the underlying writer.
+            ///
+            /// Note that this may discard internal state of this encoder, so care should be taken
+            /// to avoid losing resources when this is called.
+            pub fn into_inner(self) -> $inner {
+                self.inner.into_inner()
+            }
+        }
+
+        impl<$inner: tokio_02::io::AsyncWrite> tokio_02::io::AsyncWrite for $name<$inner> {
+            fn poll_write(
+                self: std::pin::Pin<&mut Self>,
+                cx: &mut std::task::Context<'_>,
+                buf: &[u8],
+            ) -> std::task::Poll<std::io::Result<usize>> {
+                self.project().inner.poll_write(cx, buf)
+            }
+
+            fn poll_flush(
+                self: std::pin::Pin<&mut Self>,
+                cx: &mut std::task::Context<'_>,
+            ) -> std::task::Poll<std::io::Result<()>> {
+                self.project().inner.poll_flush(cx)
+            }
+
+            fn poll_shutdown(
+                self: std::pin::Pin<&mut Self>,
+                cx: &mut std::task::Context<'_>,
+            ) -> std::task::Poll<std::io::Result<()>> {
+                self.project().inner.poll_shutdown(cx)
+            }
+        }
+
+        const _: () = {
+            fn _assert() {
+                use crate::util::{_assert_send, _assert_sync};
+                use core::pin::Pin;
+                use tokio_02::io::AsyncWrite;
+
+                _assert_send::<$name<Pin<Box<dyn AsyncWrite + Send>>>>();
+                _assert_sync::<$name<Pin<Box<dyn AsyncWrite + Sync>>>>();
+            }
+        };
+    }
+}

--- a/src/tokio_02/write/macros/mod.rs
+++ b/src/tokio_02/write/macros/mod.rs
@@ -1,0 +1,4 @@
+#[macro_use]
+mod decoder;
+#[macro_use]
+mod encoder;

--- a/src/tokio_02/write/mod.rs
+++ b/src/tokio_02/write/mod.rs
@@ -1,0 +1,17 @@
+//! Types which operate over [`AsyncWrite`](tokio_02::io::AsyncWrite) streams, both encoders and
+//! decoders for various formats.
+
+#[macro_use]
+mod macros;
+mod generic;
+
+mod buf_write;
+mod buf_writer;
+
+use self::{
+    buf_write::AsyncBufWrite,
+    buf_writer::BufWriter,
+    generic::{Decoder, Encoder},
+};
+
+algos!(tokio_02::write<W>);

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -65,8 +65,8 @@ macro_rules! tests {
                     }
                 }
 
+                #[cfg(feature = "futures-io")]
                 mod futures {
-                    #[cfg(feature = "futures-bufread")]
                     mod bufread {
                         use crate::utils;
                         use proptest::{prelude::{any, ProptestConfig}, proptest};
@@ -108,7 +108,6 @@ macro_rules! tests {
                         }
                     }
 
-                    #[cfg(feature = "futures-write")]
                     mod write {
                         use crate::utils;
                         use proptest::{prelude::{any, ProptestConfig}, proptest};
@@ -146,8 +145,8 @@ macro_rules! tests {
                     }
                 }
 
+                #[cfg(feature = "tokio-02")]
                 mod tokio_02 {
-                    #[cfg(feature = "tokio-02-bufread")]
                     mod bufread {
                         use crate::utils;
                         use proptest::{prelude::{any, ProptestConfig}, proptest};
@@ -189,7 +188,6 @@ macro_rules! tests {
                         }
                     }
 
-                    #[cfg(feature = "tokio-02-write")]
                     mod write {
                         use crate::utils;
                         use proptest::{prelude::{any, ProptestConfig}, proptest};

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -145,6 +145,87 @@ macro_rules! tests {
                         }
                     }
                 }
+
+                mod tokio_02 {
+                    #[cfg(feature = "tokio-02-bufread")]
+                    mod bufread {
+                        use crate::utils;
+                        use proptest::{prelude::{any, ProptestConfig}, proptest};
+                        use std::iter::FromIterator;
+
+                        proptest! {
+                            #[test]
+                            fn compress(ref input in any::<utils::InputStream>()) {
+                                let compressed = utils::$name::tokio_02::bufread::compress(input.tokio_reader());
+                                let output = utils::$name::sync::decompress(&compressed);
+                                assert_eq!(output, input.bytes());
+                            }
+
+                            #[test]
+                            fn decompress(
+                                ref input in any::<Vec<u8>>(),
+                                chunk_size in 1..20usize,
+                            ) {
+                                let compressed = utils::$name::sync::compress(input);
+                                let stream = utils::InputStream::from(Vec::from_iter(compressed.chunks(chunk_size).map(Vec::from)));
+                                let output = utils::$name::tokio_02::bufread::decompress(stream.tokio_reader());
+                                assert_eq!(&output, input);
+                            }
+                        }
+
+                        proptest! {
+                            #![proptest_config(ProptestConfig::with_cases(32))]
+
+                            #[test]
+                            fn compress_with_level(
+                                ref input in any::<utils::InputStream>(),
+                                level in crate::any_level(),
+                            ) {
+                                let encoder = utils::$name::tokio_02::bufread::Encoder::with_quality(input.tokio_reader(), level);
+                                let compressed = utils::prelude::tokio_read_to_vec(encoder);
+                                let output = utils::$name::sync::decompress(&compressed);
+                                assert_eq!(output, input.bytes());
+                            }
+                        }
+                    }
+
+                    #[cfg(feature = "tokio-02-write")]
+                    mod write {
+                        use crate::utils;
+                        use proptest::{prelude::{any, ProptestConfig}, proptest};
+
+                        proptest! {
+                            #[test]
+                            fn compress(
+                                ref input in any::<utils::InputStream>(),
+                                limit in 1..20usize,
+                            ) {
+                                let compressed = utils::$name::tokio_02::write::compress(input.as_ref(), limit);
+                                let output = utils::$name::sync::decompress(&compressed);
+                                assert_eq!(output, input.bytes());
+                            }
+                        }
+
+                        proptest! {
+                            #![proptest_config(ProptestConfig::with_cases(32))]
+
+                            #[test]
+                            fn compress_with_level(
+                                ref input in any::<utils::InputStream>(),
+                                limit in 1..20usize,
+                                level in crate::any_level(),
+                            ) {
+                                let compressed = utils::prelude::tokio_write_to_vec(
+                                    input.as_ref(),
+                                    |input| Box::pin(utils::$name::tokio_02::write::Encoder::with_quality(input, level)),
+                                    limit,
+                                );
+                                let output = utils::$name::sync::decompress(&compressed);
+                                assert_eq!(output, input.bytes());
+                            }
+                        }
+                    }
+                }
             }
         )*
     }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code, unused_macros)] // Different tests use a different subset of functions
 
+#[cfg(any(feature = "tokio-02-bufread", feature = "tokio-02-write"))]
+mod tokio_02_ext;
 mod track_closed;
 
 use proptest_derive::Arbitrary;
@@ -50,6 +52,26 @@ impl InputStream {
         .into_async_read()
     }
 
+    #[cfg(feature = "tokio-02-bufread")]
+    pub fn tokio_reader(&self) -> impl tokio_02::io::AsyncBufRead {
+        use bytes::Bytes;
+        use futures_test::stream::StreamTestExt;
+        // TODO: By using the stream here we ensure that each chunk will require a separate
+        // read/poll_fill_buf call to process to help test reading multiple chunks.
+        tokio_02::io::stream_reader(
+            futures::stream::iter(
+                self.0
+                    .clone()
+                    .into_iter()
+                    .map(Bytes::from)
+                    .flat_map(|bytes| vec![Bytes::new(), bytes])
+                    .chain(Some(Bytes::new()))
+                    .map(Ok),
+            )
+            .interleave_pending(),
+        )
+    }
+
     pub fn bytes(&self) -> Vec<u8> {
         self.0.iter().flatten().cloned().collect()
     }
@@ -72,26 +94,24 @@ impl From<Vec<Vec<u8>>> for InputStream {
 }
 
 pub mod prelude {
+    pub use super::track_closed::TrackClosed;
     pub use async_compression::Level;
     #[cfg(feature = "stream")]
     pub use bytes::Bytes;
     pub use futures::{
         executor::{block_on, block_on_stream},
-        io::{
-            copy_buf, AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite,
-            AsyncWriteExt, BufReader, Cursor,
-        },
+        io::{AsyncBufRead, AsyncRead, AsyncWrite},
         pin_mut,
-        stream::{self, Stream, TryStreamExt},
-    };
-    pub use futures_test::{
-        io::{AsyncReadTestExt, AsyncWriteTestExt},
-        stream::StreamTestExt,
+        stream::{self, Stream},
     };
     pub use std::{
         io::{self, Read},
         pin::Pin,
     };
+    #[cfg(feature = "tokio-02-write")]
+    pub use tokio_02::io::AsyncWrite as TokioWrite;
+    #[cfg(feature = "tokio-02-bufread")]
+    pub use tokio_02::io::{AsyncBufRead as TokioBufRead, AsyncRead as TokioRead};
 
     pub fn read_to_vec(mut read: impl Read) -> Vec<u8> {
         let mut output = vec![];
@@ -103,9 +123,13 @@ pub mod prelude {
     pub fn async_read_to_vec(read: impl AsyncRead) -> Vec<u8> {
         // TODO: https://github.com/rust-lang-nursery/futures-rs/issues/1510
         // All current test cases are < 100kB
-        let mut output = Cursor::new(vec![0; 102_400]);
+        let mut output = futures::io::Cursor::new(vec![0; 102_400]);
         pin_mut!(read);
-        let len = block_on(copy_buf(BufReader::with_capacity(2, read), &mut output)).unwrap();
+        let len = block_on(futures::io::copy_buf(
+            futures::io::BufReader::with_capacity(2, read),
+            &mut output,
+        ))
+        .unwrap();
         let mut output = output.into_inner();
         output.truncate(len as usize);
         output
@@ -119,14 +143,16 @@ pub mod prelude {
         ) -> Pin<Box<dyn AsyncWrite + 'a>>,
         limit: usize,
     ) -> Vec<u8> {
-        use crate::utils::track_closed::TrackClosedExt as _;
+        use futures::io::AsyncWriteExt as _;
+        use futures_test::io::AsyncWriteTestExt as _;
 
         let mut output = Vec::new();
         {
-            let mut test_writer = (&mut output)
-                .limited_write(limit)
-                .interleave_pending_write()
-                .track_closed();
+            let mut test_writer = TrackClosed::new(
+                (&mut output)
+                    .limited_write(limit)
+                    .interleave_pending_write(),
+            );
             {
                 let mut writer = create_writer(&mut test_writer);
                 for chunk in input {
@@ -147,6 +173,51 @@ pub mod prelude {
             .map(Result::unwrap)
             .flatten()
             .collect()
+    }
+
+    #[cfg(feature = "tokio-02-bufread")]
+    pub fn tokio_read_to_vec(read: impl TokioRead) -> Vec<u8> {
+        let mut output = std::io::Cursor::new(vec![0; 102_400]);
+        pin_mut!(read);
+        let len = block_on(crate::utils::tokio_02_ext::copy_buf(
+            tokio_02::io::BufReader::with_capacity(2, read),
+            &mut output,
+        ))
+        .unwrap();
+        let mut output = output.into_inner();
+        output.truncate(len as usize);
+        output
+    }
+
+    #[cfg(feature = "tokio-02-write")]
+    pub fn tokio_write_to_vec(
+        input: &[Vec<u8>],
+        create_writer: impl for<'a> FnOnce(
+            &'a mut (dyn TokioWrite + Unpin),
+        ) -> Pin<Box<dyn TokioWrite + 'a>>,
+        limit: usize,
+    ) -> Vec<u8> {
+        use crate::utils::tokio_02_ext::AsyncWriteTestExt;
+        use tokio_02::io::AsyncWriteExt as _;
+
+        let mut output = std::io::Cursor::new(Vec::new());
+        {
+            let mut test_writer = TrackClosed::new(
+                (&mut output)
+                    .limited_write(limit)
+                    .interleave_pending_write(),
+            );
+            {
+                let mut writer = create_writer(&mut test_writer);
+                for chunk in input {
+                    block_on(writer.write_all(chunk)).unwrap();
+                    block_on(writer.flush()).unwrap();
+                }
+                block_on(writer.shutdown()).unwrap();
+            }
+            assert!(test_writer.is_closed());
+        }
+        output.into_inner()
     }
 }
 
@@ -209,6 +280,46 @@ macro_rules! algos {
 
                         pub fn decompress(input: &[Vec<u8>], limit: usize) -> Vec<u8> {
                             async_write_to_vec(input, |input| Box::pin(Decoder::new(input)), limit)
+                        }
+                    }
+                }
+
+                pub mod tokio_02 {
+                    #[cfg(feature = "tokio-02-bufread")]
+                    pub mod bufread {
+                        use crate::utils::prelude::*;
+                        pub use async_compression::tokio_02::bufread::{
+                            $decoder as Decoder, $encoder as Encoder,
+                        };
+
+                        pub fn compress(input: impl TokioBufRead) -> Vec<u8> {
+                            pin_mut!(input);
+                            tokio_read_to_vec(Encoder::with_quality(input, Level::Fastest))
+                        }
+
+                        pub fn decompress(input: impl TokioBufRead) -> Vec<u8> {
+                            pin_mut!(input);
+                            tokio_read_to_vec(Decoder::new(input))
+                        }
+                    }
+
+                    #[cfg(feature = "tokio-02-write")]
+                    pub mod write {
+                        use crate::utils::prelude::*;
+                        pub use async_compression::tokio_02::write::{
+                            $decoder as Decoder, $encoder as Encoder,
+                        };
+
+                        pub fn compress(input: &[Vec<u8>], limit: usize) -> Vec<u8> {
+                            tokio_write_to_vec(
+                                input,
+                                |input| Box::pin(Encoder::with_quality(input, Level::Fastest)),
+                                limit,
+                            )
+                        }
+
+                        pub fn decompress(input: &[Vec<u8>], limit: usize) -> Vec<u8> {
+                            tokio_write_to_vec(input, |input| Box::pin(Decoder::new(input)), limit)
                         }
                     }
                 }
@@ -1021,6 +1132,446 @@ macro_rules! test_cases {
                                 compressed.chunks(1024).map(Vec::from).collect::<Vec<_>>(),
                             );
                             let output = utils::$variant::futures::write::decompress(
+                                stream.as_ref(),
+                                65_536,
+                            );
+
+                            assert_eq!(output, input);
+                        }
+                    }
+                }
+            }
+
+            mod tokio_02 {
+                #[cfg(feature = "tokio-02-bufread")]
+                mod bufread {
+                    mod compress {
+                        use crate::utils::{self, prelude::*};
+                        use std::iter::FromIterator;
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn empty() {
+                            let mut input: &[u8] = &[];
+                            let compressed =
+                                utils::$variant::tokio_02::bufread::compress(&mut input);
+                            let output = utils::$variant::sync::decompress(&compressed);
+
+                            assert_eq!(output, &[][..]);
+                        }
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn empty_chunk() {
+                            let input = utils::InputStream::from(vec![vec![]]);
+
+                            let compressed =
+                                utils::$variant::tokio_02::bufread::compress(input.tokio_reader());
+                            let output = utils::$variant::sync::decompress(&compressed);
+
+                            assert_eq!(output, input.bytes());
+                        }
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn short() {
+                            let input = utils::InputStream::from([[1, 2, 3], [4, 5, 6]]);
+
+                            let compressed =
+                                utils::$variant::tokio_02::bufread::compress(input.tokio_reader());
+                            let output = utils::$variant::sync::decompress(&compressed);
+
+                            assert_eq!(output, &[1, 2, 3, 4, 5, 6][..]);
+                        }
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn long() {
+                            let input = vec![
+                                Vec::from_iter((0..32_768).map(|_| rand::random())),
+                                Vec::from_iter((0..32_768).map(|_| rand::random())),
+                            ];
+                            let input = utils::InputStream::from(input);
+
+                            let compressed =
+                                utils::$variant::tokio_02::bufread::compress(input.tokio_reader());
+                            let output = utils::$variant::sync::decompress(&compressed);
+
+                            assert_eq!(output, input.bytes());
+                        }
+
+                        #[test]
+                        fn with_level_0() {
+                            let input = utils::InputStream::from([[1, 2, 3], [4, 5, 6]]);
+
+                            let encoder = utils::$variant::tokio_02::bufread::Encoder::with_quality(
+                                input.tokio_reader(),
+                                Level::Precise(0),
+                            );
+                            let compressed = tokio_read_to_vec(encoder);
+                            let output = utils::$variant::sync::decompress(&compressed);
+
+                            assert_eq!(output, &[1, 2, 3, 4, 5, 6][..]);
+                        }
+
+                        #[test]
+                        fn with_level_max() {
+                            let input = utils::InputStream::from([[1, 2, 3], [4, 5, 6]]);
+
+                            let encoder = utils::$variant::tokio_02::bufread::Encoder::with_quality(
+                                input.tokio_reader(),
+                                Level::Precise(u32::max_value()),
+                            );
+                            let compressed = tokio_read_to_vec(encoder);
+                            let output = utils::$variant::sync::decompress(&compressed);
+
+                            assert_eq!(output, &[1, 2, 3, 4, 5, 6][..]);
+                        }
+                    }
+
+                    mod decompress {
+                        use crate::utils::{self, prelude::*};
+                        use std::iter::FromIterator;
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn empty() {
+                            let compressed = utils::$variant::sync::compress(&[]);
+
+                            let stream = utils::InputStream::from(vec![compressed]);
+                            let output = utils::$variant::tokio_02::bufread::decompress(
+                                stream.tokio_reader(),
+                            );
+
+                            assert_eq!(output, &[][..]);
+                        }
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn zeros() {
+                            let compressed = utils::$variant::sync::compress(&[0; 10]);
+
+                            let stream = utils::InputStream::from(vec![compressed]);
+                            let output = utils::$variant::tokio_02::bufread::decompress(
+                                stream.tokio_reader(),
+                            );
+
+                            assert_eq!(output, &[0; 10][..]);
+                        }
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn short() {
+                            let compressed = utils::$variant::sync::compress(&[1, 2, 3, 4, 5, 6]);
+
+                            let stream = utils::InputStream::from(vec![compressed]);
+                            let output = utils::$variant::tokio_02::bufread::decompress(
+                                stream.tokio_reader(),
+                            );
+
+                            assert_eq!(output, &[1, 2, 3, 4, 5, 6][..]);
+                        }
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn short_chunks() {
+                            let compressed = utils::$variant::sync::compress(&[1, 2, 3, 4, 5, 6]);
+
+                            let stream = utils::InputStream::from(
+                                compressed.chunks(2).map(Vec::from).collect::<Vec<_>>(),
+                            );
+                            let output = utils::$variant::tokio_02::bufread::decompress(
+                                stream.tokio_reader(),
+                            );
+
+                            assert_eq!(output, &[1, 2, 3, 4, 5, 6][..]);
+                        }
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn trailer() {
+                            let mut compressed =
+                                utils::$variant::sync::compress(&[1, 2, 3, 4, 5, 6]);
+
+                            compressed.extend_from_slice(&[7, 8, 9, 10]);
+
+                            let stream = utils::InputStream::from(vec![compressed]);
+                            let mut reader = stream.tokio_reader();
+                            let output =
+                                utils::$variant::tokio_02::bufread::decompress(&mut reader);
+                            let trailer = tokio_read_to_vec(reader);
+
+                            assert_eq!(output, &[1, 2, 3, 4, 5, 6][..]);
+                            assert_eq!(trailer, &[7, 8, 9, 10][..]);
+                        }
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn long() {
+                            let input = Vec::from_iter((0..65_536).map(|_| rand::random()));
+                            let compressed = utils::$variant::sync::compress(&input);
+
+                            let stream = utils::InputStream::from(vec![compressed]);
+                            let output = utils::$variant::tokio_02::bufread::decompress(
+                                stream.tokio_reader(),
+                            );
+
+                            assert_eq!(output, input);
+                        }
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn long_chunks() {
+                            let input = Vec::from_iter((0..65_536).map(|_| rand::random()));
+                            let compressed = utils::$variant::sync::compress(&input);
+
+                            let stream = utils::InputStream::from(
+                                compressed.chunks(1024).map(Vec::from).collect::<Vec<_>>(),
+                            );
+                            let output = utils::$variant::tokio_02::bufread::decompress(
+                                stream.tokio_reader(),
+                            );
+
+                            assert_eq!(output, input);
+                        }
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn multiple_members() {
+                            let compressed = [
+                                utils::$variant::sync::compress(&[1, 2, 3, 4, 5, 6]),
+                                utils::$variant::sync::compress(&[6, 5, 4, 3, 2, 1]),
+                            ]
+                            .join(&[][..]);
+
+                            let stream = utils::InputStream::from(vec![compressed]);
+
+                            let mut decoder = utils::$variant::tokio_02::bufread::Decoder::new(
+                                stream.tokio_reader(),
+                            );
+                            decoder.multiple_members(true);
+                            let output = utils::prelude::tokio_read_to_vec(decoder);
+
+                            assert_eq!(output, &[1, 2, 3, 4, 5, 6, 6, 5, 4, 3, 2, 1][..]);
+                        }
+                    }
+                }
+
+                #[cfg(feature = "tokio-02-write")]
+                mod write {
+                    mod compress {
+                        use crate::utils::{self, prelude::*};
+                        use std::iter::FromIterator;
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn empty() {
+                            let input = utils::InputStream::from(vec![]);
+                            let compressed =
+                                utils::$variant::tokio_02::write::compress(input.as_ref(), 65_536);
+                            let output = utils::$variant::sync::decompress(&compressed);
+
+                            assert_eq!(output, &[][..]);
+                        }
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn empty_chunk() {
+                            let input = utils::InputStream::from(vec![vec![]]);
+
+                            let compressed =
+                                utils::$variant::tokio_02::write::compress(input.as_ref(), 65_536);
+                            let output = utils::$variant::sync::decompress(&compressed);
+
+                            assert_eq!(output, input.bytes());
+                        }
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn short() {
+                            let input = utils::InputStream::from([[1, 2, 3], [4, 5, 6]]);
+
+                            let compressed =
+                                utils::$variant::tokio_02::write::compress(input.as_ref(), 65_536);
+                            let output = utils::$variant::sync::decompress(&compressed);
+
+                            assert_eq!(output, &[1, 2, 3, 4, 5, 6][..]);
+                        }
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn short_chunk_output() {
+                            let input = utils::InputStream::from([[1, 2, 3], [4, 5, 6]]);
+
+                            let compressed =
+                                utils::$variant::tokio_02::write::compress(input.as_ref(), 2);
+                            let output = utils::$variant::sync::decompress(&compressed);
+
+                            assert_eq!(output, &[1, 2, 3, 4, 5, 6][..]);
+                        }
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn long() {
+                            let input = vec![
+                                Vec::from_iter((0..32_768).map(|_| rand::random())),
+                                Vec::from_iter((0..32_768).map(|_| rand::random())),
+                            ];
+                            let input = utils::InputStream::from(input);
+
+                            let compressed =
+                                utils::$variant::tokio_02::write::compress(input.as_ref(), 65_536);
+                            let output = utils::$variant::sync::decompress(&compressed);
+
+                            assert_eq!(output, input.bytes());
+                        }
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn long_chunk_output() {
+                            let input = vec![
+                                Vec::from_iter((0..32_768).map(|_| rand::random())),
+                                Vec::from_iter((0..32_768).map(|_| rand::random())),
+                            ];
+                            let input = utils::InputStream::from(input);
+
+                            let compressed =
+                                utils::$variant::tokio_02::write::compress(input.as_ref(), 20);
+                            let output = utils::$variant::sync::decompress(&compressed);
+
+                            assert_eq!(output, input.bytes());
+                        }
+
+                        #[test]
+                        fn with_level_0() {
+                            let input = utils::InputStream::from([[1, 2, 3], [4, 5, 6]]);
+
+                            let compressed = tokio_write_to_vec(
+                                input.as_ref(),
+                                |input| {
+                                    Box::pin(
+                                        utils::$variant::tokio_02::write::Encoder::with_quality(
+                                            input,
+                                            Level::Precise(0),
+                                        ),
+                                    )
+                                },
+                                65_536,
+                            );
+                            let output = utils::$variant::sync::decompress(&compressed);
+
+                            assert_eq!(output, &[1, 2, 3, 4, 5, 6][..]);
+                        }
+
+                        #[test]
+                        fn with_level_max() {
+                            let input = utils::InputStream::from([[1, 2, 3], [4, 5, 6]]);
+
+                            let compressed = tokio_write_to_vec(
+                                input.as_ref(),
+                                |input| {
+                                    Box::pin(
+                                        utils::$variant::tokio_02::write::Encoder::with_quality(
+                                            input,
+                                            Level::Precise(u32::max_value()),
+                                        ),
+                                    )
+                                },
+                                65_536,
+                            );
+                            let output = utils::$variant::sync::decompress(&compressed);
+
+                            assert_eq!(output, &[1, 2, 3, 4, 5, 6][..]);
+                        }
+                    }
+
+                    mod decompress {
+                        use crate::utils;
+                        use std::iter::FromIterator;
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn empty() {
+                            let compressed = utils::$variant::sync::compress(&[]);
+
+                            let stream = utils::InputStream::from(vec![compressed]);
+                            let output = utils::$variant::tokio_02::write::decompress(
+                                stream.as_ref(),
+                                65_536,
+                            );
+
+                            assert_eq!(output, &[][..]);
+                        }
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn zeros() {
+                            let compressed = utils::$variant::sync::compress(&[0; 10]);
+
+                            let stream = utils::InputStream::from(vec![compressed]);
+                            let output = utils::$variant::tokio_02::write::decompress(
+                                stream.as_ref(),
+                                65_536,
+                            );
+
+                            assert_eq!(output, &[0; 10][..]);
+                        }
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn short() {
+                            let compressed = utils::$variant::sync::compress(&[1, 2, 3, 4, 5, 6]);
+
+                            let stream = utils::InputStream::from(vec![compressed]);
+                            let output = utils::$variant::tokio_02::write::decompress(
+                                stream.as_ref(),
+                                65_536,
+                            );
+
+                            assert_eq!(output, &[1, 2, 3, 4, 5, 6][..]);
+                        }
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn short_chunks() {
+                            let compressed = utils::$variant::sync::compress(&[1, 2, 3, 4, 5, 6]);
+
+                            let stream = utils::InputStream::from(
+                                compressed.chunks(2).map(Vec::from).collect::<Vec<_>>(),
+                            );
+                            let output = utils::$variant::tokio_02::write::decompress(
+                                stream.as_ref(),
+                                65_536,
+                            );
+
+                            assert_eq!(output, &[1, 2, 3, 4, 5, 6][..]);
+                        }
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn long() {
+                            let input = Vec::from_iter((0..65_536).map(|_| rand::random()));
+                            let compressed = utils::$variant::sync::compress(&input);
+
+                            let stream = utils::InputStream::from(vec![compressed]);
+                            let output = utils::$variant::tokio_02::write::decompress(
+                                stream.as_ref(),
+                                65_536,
+                            );
+
+                            assert_eq!(output, input);
+                        }
+
+                        #[test]
+                        #[ntest::timeout(1000)]
+                        fn long_chunks() {
+                            let input = Vec::from_iter((0..65_536).map(|_| rand::random()));
+                            let compressed = utils::$variant::sync::compress(&input);
+
+                            let stream = utils::InputStream::from(
+                                compressed.chunks(1024).map(Vec::from).collect::<Vec<_>>(),
+                            );
+                            let output = utils::$variant::tokio_02::write::decompress(
                                 stream.as_ref(),
                                 65_536,
                             );

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -2,6 +2,7 @@
 
 #[cfg(any(feature = "tokio-02-bufread", feature = "tokio-02-write"))]
 mod tokio_02_ext;
+#[cfg(any(feature = "futures-write", feature = "tokio-02-write"))]
 mod track_closed;
 
 use proptest_derive::Arbitrary;
@@ -94,7 +95,6 @@ impl From<Vec<Vec<u8>>> for InputStream {
 }
 
 pub mod prelude {
-    pub use super::track_closed::TrackClosed;
     pub use async_compression::Level;
     #[cfg(feature = "stream")]
     pub use bytes::Bytes;
@@ -143,6 +143,7 @@ pub mod prelude {
         ) -> Pin<Box<dyn AsyncWrite + 'a>>,
         limit: usize,
     ) -> Vec<u8> {
+        use crate::utils::track_closed::TrackClosed;
         use futures::io::AsyncWriteExt as _;
         use futures_test::io::AsyncWriteTestExt as _;
 
@@ -198,6 +199,7 @@ pub mod prelude {
         limit: usize,
     ) -> Vec<u8> {
         use crate::utils::tokio_02_ext::AsyncWriteTestExt;
+        use crate::utils::track_closed::TrackClosed;
         use tokio_02::io::AsyncWriteExt as _;
 
         let mut output = std::io::Cursor::new(Vec::new());

--- a/tests/utils/tokio_02_ext/copy_buf.rs
+++ b/tests/utils/tokio_02_ext/copy_buf.rs
@@ -1,0 +1,52 @@
+use core::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use futures::ready;
+use tokio_02::io::{AsyncBufRead, AsyncWrite};
+
+pub fn copy_buf<R, W>(reader: R, writer: &mut W) -> CopyBuf<'_, R, W>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin + ?Sized,
+{
+    CopyBuf {
+        reader,
+        writer,
+        amt: 0,
+    }
+}
+
+#[derive(Debug)]
+pub struct CopyBuf<'a, R, W: ?Sized> {
+    reader: R,
+    writer: &'a mut W,
+    amt: u64,
+}
+
+impl<R, W> Future for CopyBuf<'_, R, W>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin + ?Sized,
+{
+    type Output = std::io::Result<u64>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = &mut *self;
+        loop {
+            let buffer = ready!(Pin::new(&mut this.reader).poll_fill_buf(cx))?;
+            if buffer.is_empty() {
+                ready!(Pin::new(&mut this.writer).poll_flush(cx))?;
+                return Poll::Ready(Ok(this.amt));
+            }
+
+            let i = ready!(Pin::new(&mut this.writer).poll_write(cx, buffer))?;
+            if i == 0 {
+                return Poll::Ready(Err(std::io::ErrorKind::WriteZero.into()));
+            }
+            this.amt += i as u64;
+            Pin::new(&mut this.reader).consume(i);
+        }
+    }
+}

--- a/tests/utils/tokio_02_ext/interleave_pending.rs
+++ b/tests/utils/tokio_02_ext/interleave_pending.rs
@@ -1,0 +1,66 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+pub struct InterleavePending<T> {
+    inner: T,
+    pended: bool,
+}
+
+impl<T> InterleavePending<T> {
+    pub(crate) fn new(inner: T) -> Self {
+        Self {
+            inner,
+            pended: false,
+        }
+    }
+}
+
+impl<W: tokio_02::io::AsyncWrite + Unpin> tokio_02::io::AsyncWrite for InterleavePending<W> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        if self.pended {
+            let next = Pin::new(&mut self.inner).poll_write(cx, buf);
+            if next.is_ready() {
+                self.pended = false;
+            }
+            next
+        } else {
+            cx.waker().wake_by_ref();
+            self.pended = true;
+            Poll::Pending
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        if self.pended {
+            let next = Pin::new(&mut self.inner).poll_flush(cx);
+            if next.is_ready() {
+                self.pended = false;
+            }
+            next
+        } else {
+            cx.waker().wake_by_ref();
+            self.pended = true;
+            Poll::Pending
+        }
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        if self.pended {
+            let next = Pin::new(&mut self.inner).poll_shutdown(cx);
+            if next.is_ready() {
+                self.pended = false;
+            }
+            next
+        } else {
+            cx.waker().wake_by_ref();
+            self.pended = true;
+            Poll::Pending
+        }
+    }
+}

--- a/tests/utils/tokio_02_ext/limited.rs
+++ b/tests/utils/tokio_02_ext/limited.rs
@@ -1,0 +1,35 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+#[derive(Debug)]
+pub struct Limited<Io> {
+    io: Io,
+    limit: usize,
+}
+
+impl<Io> Limited<Io> {
+    pub(crate) fn new(io: Io, limit: usize) -> Limited<Io> {
+        Limited { io, limit }
+    }
+}
+
+impl<W: tokio_02::io::AsyncWrite + Unpin> tokio_02::io::AsyncWrite for Limited<W> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let limit = self.limit;
+        Pin::new(&mut self.io).poll_write(cx, &buf[..std::cmp::min(limit, buf.len())])
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.io).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.io).poll_shutdown(cx)
+    }
+}

--- a/tests/utils/tokio_02_ext/mod.rs
+++ b/tests/utils/tokio_02_ext/mod.rs
@@ -1,0 +1,29 @@
+#[cfg(feature = "tokio-02-bufread")]
+mod copy_buf;
+#[cfg(feature = "tokio-02-write")]
+mod interleave_pending;
+#[cfg(feature = "tokio-02-write")]
+mod limited;
+
+#[cfg(feature = "tokio-02-bufread")]
+pub use copy_buf::copy_buf;
+
+#[cfg(feature = "tokio-02-write")]
+pub trait AsyncWriteTestExt: tokio_02::io::AsyncWrite {
+    fn interleave_pending_write(self) -> interleave_pending::InterleavePending<Self>
+    where
+        Self: Sized + Unpin,
+    {
+        interleave_pending::InterleavePending::new(self)
+    }
+
+    fn limited_write(self, limit: usize) -> limited::Limited<Self>
+    where
+        Self: Sized + Unpin,
+    {
+        limited::Limited::new(self, limit)
+    }
+}
+
+#[cfg(feature = "tokio-02-write")]
+impl<T: tokio_02::io::AsyncWrite> AsyncWriteTestExt for T {}

--- a/tests/utils/tokio_02_ext/mod.rs
+++ b/tests/utils/tokio_02_ext/mod.rs
@@ -1,14 +1,9 @@
-#[cfg(feature = "tokio-02-bufread")]
 mod copy_buf;
-#[cfg(feature = "tokio-02-write")]
 mod interleave_pending;
-#[cfg(feature = "tokio-02-write")]
 mod limited;
 
-#[cfg(feature = "tokio-02-bufread")]
 pub use copy_buf::copy_buf;
 
-#[cfg(feature = "tokio-02-write")]
 pub trait AsyncWriteTestExt: tokio_02::io::AsyncWrite {
     fn interleave_pending_write(self) -> interleave_pending::InterleavePending<Self>
     where
@@ -25,5 +20,4 @@ pub trait AsyncWriteTestExt: tokio_02::io::AsyncWrite {
     }
 }
 
-#[cfg(feature = "tokio-02-write")]
 impl<T: tokio_02::io::AsyncWrite> AsyncWriteTestExt for T {}

--- a/tests/utils/track_closed.rs
+++ b/tests/utils/track_closed.rs
@@ -22,7 +22,7 @@ impl<W> TrackClosed<W> {
     }
 }
 
-#[cfg(feature = "futures-write")]
+#[cfg(feature = "futures-io")]
 impl<W: futures_io::AsyncWrite + Unpin> futures_io::AsyncWrite for TrackClosed<W> {
     fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<Result<usize>> {
         assert!(!self.closed);
@@ -55,7 +55,7 @@ impl<W: futures_io::AsyncWrite + Unpin> futures_io::AsyncWrite for TrackClosed<W
     }
 }
 
-#[cfg(feature = "tokio-02-write")]
+#[cfg(feature = "tokio-02")]
 impl<W: tokio_02::io::AsyncWrite + Unpin> tokio_02::io::AsyncWrite for TrackClosed<W> {
     fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<Result<usize>> {
         assert!(!self.closed);

--- a/tests/utils/track_closed.rs
+++ b/tests/utils/track_closed.rs
@@ -2,35 +2,28 @@ use core::{
     pin::Pin,
     task::{Context, Poll},
 };
-use futures::io::AsyncWrite;
 use std::io::{IoSlice, Result};
 
-pub trait TrackClosedExt: AsyncWrite {
-    fn track_closed(self) -> TrackClosed<Self>
-    where
-        Self: Sized + Unpin,
-    {
-        TrackClosed {
-            inner: self,
-            closed: false,
-        }
-    }
-}
-
-impl<W: AsyncWrite> TrackClosedExt for W {}
-
-pub struct TrackClosed<W: AsyncWrite + Unpin> {
+pub struct TrackClosed<W> {
     inner: W,
     closed: bool,
 }
 
-impl<W: AsyncWrite + Unpin> TrackClosed<W> {
+impl<W> TrackClosed<W> {
+    pub fn new(inner: W) -> Self {
+        Self {
+            inner,
+            closed: false,
+        }
+    }
+
     pub fn is_closed(&self) -> bool {
         self.closed
     }
 }
 
-impl<W: AsyncWrite + Unpin> AsyncWrite for TrackClosed<W> {
+#[cfg(feature = "futures-write")]
+impl<W: futures_io::AsyncWrite + Unpin> futures_io::AsyncWrite for TrackClosed<W> {
     fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<Result<usize>> {
         assert!(!self.closed);
         Pin::new(&mut self.inner).poll_write(cx, buf)
@@ -59,5 +52,29 @@ impl<W: AsyncWrite + Unpin> AsyncWrite for TrackClosed<W> {
     ) -> Poll<Result<usize>> {
         assert!(!self.closed);
         Pin::new(&mut self.inner).poll_write_vectored(cx, bufs)
+    }
+}
+
+#[cfg(feature = "tokio-02-write")]
+impl<W: tokio_02::io::AsyncWrite + Unpin> tokio_02::io::AsyncWrite for TrackClosed<W> {
+    fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<Result<usize>> {
+        assert!(!self.closed);
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<()>> {
+        assert!(!self.closed);
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<()>> {
+        assert!(!self.closed);
+        match Pin::new(&mut self.inner).poll_shutdown(cx) {
+            Poll::Ready(Ok(())) => {
+                self.closed = true;
+                Poll::Ready(Ok(()))
+            }
+            other => other,
+        }
     }
 }

--- a/tests/utils/track_closed.rs
+++ b/tests/utils/track_closed.rs
@@ -2,7 +2,7 @@ use core::{
     pin::Pin,
     task::{Context, Poll},
 };
-use std::io::{IoSlice, Result};
+use std::io::Result;
 
 pub struct TrackClosed<W> {
     inner: W,
@@ -48,7 +48,7 @@ impl<W: futures_io::AsyncWrite + Unpin> futures_io::AsyncWrite for TrackClosed<W
     fn poll_write_vectored(
         mut self: Pin<&mut Self>,
         cx: &mut Context,
-        bufs: &[IoSlice],
+        bufs: &[std::io::IoSlice],
     ) -> Poll<Result<usize>> {
         assert!(!self.closed);
         Pin::new(&mut self.inner).poll_write_vectored(cx, bufs)


### PR DESCRIPTION
Terribad copy-paste job, but any cleanup to reduce duplication shouldn't affect public API so easy path is to get this in first.

fixes #57 