### PR TITLE
Use only `std` feature for `brotli`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ futures-write = ["futures-io"]
 
 [dependencies]
 xz2 = { version = "0.1.6", optional = true }
-brotli = { version = "3.3.0", optional = true }
+brotli = { version = "3.3.0", optional = true, default-features = false, features = ["std"] }
 bytes-05 = { package = "bytes", version = "0.5.0", optional = true }
 bzip2 = { version = "0.4.1" , optional = true }
 flate2 = { version = "1.0.11", optional = true }


### PR DESCRIPTION
Closes https://github.com/Nemo157/async-compression/issues/83 by disabling `ffi-api` feature thanks to https://github.com/dropbox/rust-brotli/pull/48
