### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ futures-core = { version = "0.3.0", default-features = false }
 futures-io = { version = "0.3.0", default-features = false, features = ["std"], optional = true }
 pin-project-lite = "0.2.0"
 libzstd = { package = "zstd", version = "0.10.0", optional = true, default-features = false }
-zstd-safe = { version = "4.1.4", optional = true, default-features = false }
+zstd-safe = { version = "5.0.1+zstd.1.5.2", optional = true, default-features = false }
 memchr = "2.2.1"
 tokio-02 = { package = "tokio", version = "0.2.21", optional = true, default-features = false }
 tokio-03 = { package = "tokio", version = "0.3.0", optional = true, default-features = false }


### PR DESCRIPTION
Upgrading zstd-safe to 5.0.1+zstd.1.5.2

Passes all tests in 
```
cargo test --all-features
```