### PR TITLE
Bump zstd dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,18 +1032,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.10.0+zstd.1.5.2"
+version = "0.11.1+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1365becbe415f3f0fcd024e2f7b45bacfb5bdd055f0dc113571394114e7bdd"
+checksum = "77a16b8414fde0414e90c612eba70985577451c4c504b99885ebed24762cb81a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "4.1.4+zstd.1.5.2"
+version = "5.0.1+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7cd17c9af1a4d6c24beb1cc54b17e2ef7b593dc92f19e9d9acad8b182bbaee"
+checksum = "7c12659121420dd6365c5c3de4901f97145b79651fb1d25814020ed2ed0585ae"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -1051,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.6.3+zstd.1.5.2"
+version = "2.0.1+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
+checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ flate2 = { version = "1.0.11", optional = true }
 futures-core = { version = "0.3.0", default-features = false }
 futures-io = { version = "0.3.0", default-features = false, features = ["std"], optional = true }
 pin-project-lite = "0.2.0"
-libzstd = { package = "zstd", version = "0.10.0", optional = true, default-features = false }
-zstd-safe = { version = "4.1.4", optional = true, default-features = false }
+libzstd = { package = "zstd", version = "0.11.1", optional = true, default-features = false }
+zstd-safe = { version = "5.0.1", optional = true, default-features = false }
 memchr = "2.2.1"
 tokio-02 = { package = "tokio", version = "0.2.21", optional = true, default-features = false }
 tokio-03 = { package = "tokio", version = "0.3.0", optional = true, default-features = false }


### PR DESCRIPTION
libzstd 0.10 -> 0.11 and zstd-safe 4.1 -> 5.0.