### PR TITLE
bufread::generic::Decoder: don't reinitialize on reader EOF

### DIFF
--- a/src/futures/bufread/generic/decoder.rs
+++ b/src/futures/bufread/generic/decoder.rs
@@ -70,6 +70,9 @@ impl<R: AsyncBufRead, D: Decode> Decoder<R, D> {
                 State::Decoding => {
                     let input = ready!(this.reader.as_mut().poll_fill_buf(cx))?;
                     if input.is_empty() {
+                        // Avoid attempting to reinitialise the decoder if the reader
+                        // has returned EOF.
+                        *this.multiple_members = false;
                         State::Flushing
                     } else {
                         let mut input = PartialBuffer::new(input);

--- a/src/tokio/bufread/generic/decoder.rs
+++ b/src/tokio/bufread/generic/decoder.rs
@@ -70,6 +70,9 @@ impl<R: AsyncBufRead, D: Decode> Decoder<R, D> {
                 State::Decoding => {
                     let input = ready!(this.reader.as_mut().poll_fill_buf(cx))?;
                     if input.is_empty() {
+                        // Avoid attempting to reinitialise the decoder if the reader
+                        // has returned EOF.
+                        *this.multiple_members = false;
                         State::Flushing
                     } else {
                         let mut input = PartialBuffer::new(input);

--- a/src/tokio_02/bufread/generic/decoder.rs
+++ b/src/tokio_02/bufread/generic/decoder.rs
@@ -70,6 +70,9 @@ impl<R: AsyncBufRead, D: Decode> Decoder<R, D> {
                 State::Decoding => {
                     let input = ready!(this.reader.as_mut().poll_fill_buf(cx))?;
                     if input.is_empty() {
+                        // Avoid attempting to reinitialise the decoder if the reader
+                        // has returned EOF.
+                        *this.multiple_members = false;
                         State::Flushing
                     } else {
                         let mut input = PartialBuffer::new(input);

--- a/src/tokio_03/bufread/generic/decoder.rs
+++ b/src/tokio_03/bufread/generic/decoder.rs
@@ -70,6 +70,9 @@ impl<R: AsyncBufRead, D: Decode> Decoder<R, D> {
                 State::Decoding => {
                     let input = ready!(this.reader.as_mut().poll_fill_buf(cx))?;
                     if input.is_empty() {
+                        // Avoid attempting to reinitialise the decoder if the reader
+                        // has returned EOF.
+                        *this.multiple_members = false;
                         State::Flushing
                     } else {
                         let mut input = PartialBuffer::new(input);

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -8,13 +8,14 @@ mod tokio_03_ext;
 #[cfg(feature = "tokio")]
 mod tokio_ext;
 mod track_closed;
+mod track_eof;
 #[macro_use]
 mod test_cases;
 
 pub mod algos;
 pub mod impls;
 
-pub use self::{input_stream::InputStream, track_closed::TrackClosed};
+pub use self::{input_stream::InputStream, track_closed::TrackClosed, track_eof::TrackEof};
 pub use async_compression::Level;
 pub use futures::{executor::block_on, pin_mut, stream::Stream};
 pub use std::{future::Future, io::Result, iter::FromIterator, pin::Pin};

--- a/tests/utils/track_eof.rs
+++ b/tests/utils/track_eof.rs
@@ -1,0 +1,184 @@
+#[cfg_attr(not(feature = "all-implementations"), allow(unused))]
+use std::{
+    io::Result,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+pub struct TrackEof<R> {
+    inner: R,
+    eof: bool,
+}
+
+impl<R: Unpin> TrackEof<R> {
+    pub fn new(inner: R) -> Self {
+        Self { inner, eof: false }
+    }
+
+    pub fn project(self: Pin<&mut Self>) -> (Pin<&mut R>, &mut bool) {
+        let Self { inner, eof } = Pin::into_inner(self);
+        (Pin::new(inner), eof)
+    }
+}
+
+#[cfg(feature = "futures-io")]
+impl<R: futures::io::AsyncRead + Unpin> futures::io::AsyncRead for TrackEof<R> {
+    fn poll_read(self: Pin<&mut Self>, cx: &mut Context, buf: &mut [u8]) -> Poll<Result<usize>> {
+        let (inner, eof) = self.project();
+        assert!(!*eof);
+        match inner.poll_read(cx, buf) {
+            Poll::Ready(Ok(0)) => {
+                if !buf.is_empty() {
+                    *eof = true;
+                }
+                Poll::Ready(Ok(0))
+            }
+            other => other,
+        }
+    }
+}
+
+#[cfg(feature = "futures-io")]
+impl<R: futures::io::AsyncBufRead + Unpin> futures::io::AsyncBufRead for TrackEof<R> {
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<&[u8]>> {
+        let (inner, eof) = self.project();
+        assert!(!*eof);
+        match inner.poll_fill_buf(cx) {
+            Poll::Ready(Ok(buf)) => {
+                if buf.is_empty() {
+                    *eof = true;
+                }
+                Poll::Ready(Ok(buf))
+            }
+            other => other,
+        }
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        self.project().0.consume(amt)
+    }
+}
+
+#[cfg(feature = "tokio-02")]
+impl<R: tokio_02::io::AsyncRead + Unpin> tokio_02::io::AsyncRead for TrackEof<R> {
+    fn poll_read(self: Pin<&mut Self>, cx: &mut Context, buf: &mut [u8]) -> Poll<Result<usize>> {
+        let (inner, eof) = self.project();
+        assert!(!*eof);
+        match inner.poll_read(cx, buf) {
+            Poll::Ready(Ok(0)) => {
+                if !buf.is_empty() {
+                    *eof = true;
+                }
+                Poll::Ready(Ok(0))
+            }
+            other => other,
+        }
+    }
+}
+
+#[cfg(feature = "tokio-02")]
+impl<R: tokio_02::io::AsyncBufRead + Unpin> tokio_02::io::AsyncBufRead for TrackEof<R> {
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<&[u8]>> {
+        let (inner, eof) = self.project();
+        assert!(!*eof);
+        match inner.poll_fill_buf(cx) {
+            Poll::Ready(Ok(buf)) => {
+                if buf.is_empty() {
+                    *eof = true;
+                }
+                Poll::Ready(Ok(buf))
+            }
+            other => other,
+        }
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        self.project().0.consume(amt)
+    }
+}
+
+#[cfg(feature = "tokio-03")]
+impl<R: tokio_03::io::AsyncRead + Unpin> tokio_03::io::AsyncRead for TrackEof<R> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &mut tokio_03::io::ReadBuf,
+    ) -> Poll<Result<()>> {
+        let (inner, eof) = self.project();
+        assert!(!*eof);
+        let len = buf.filled().len();
+        match inner.poll_read(cx, buf) {
+            Poll::Ready(Ok(())) => {
+                if buf.filled().len() == len && buf.remaining() > 0 {
+                    *eof = true;
+                }
+                Poll::Ready(Ok(()))
+            }
+            other => other,
+        }
+    }
+}
+
+#[cfg(feature = "tokio-03")]
+impl<R: tokio_03::io::AsyncBufRead + Unpin> tokio_03::io::AsyncBufRead for TrackEof<R> {
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<&[u8]>> {
+        let (inner, eof) = self.project();
+        assert!(!*eof);
+        match inner.poll_fill_buf(cx) {
+            Poll::Ready(Ok(buf)) => {
+                if buf.is_empty() {
+                    *eof = true;
+                }
+                Poll::Ready(Ok(buf))
+            }
+            other => other,
+        }
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        self.project().0.consume(amt)
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<R: tokio::io::AsyncRead + Unpin> tokio::io::AsyncRead for TrackEof<R> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &mut tokio::io::ReadBuf,
+    ) -> Poll<Result<()>> {
+        let (inner, eof) = self.project();
+        assert!(!*eof);
+        let len = buf.filled().len();
+        match inner.poll_read(cx, buf) {
+            Poll::Ready(Ok(())) => {
+                if buf.filled().len() == len && buf.remaining() > 0 {
+                    *eof = true;
+                }
+                Poll::Ready(Ok(()))
+            }
+            other => other,
+        }
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<R: tokio::io::AsyncBufRead + Unpin> tokio::io::AsyncBufRead for TrackEof<R> {
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<&[u8]>> {
+        let (inner, eof) = self.project();
+        assert!(!*eof);
+        match inner.poll_fill_buf(cx) {
+            Poll::Ready(Ok(buf)) => {
+                if buf.is_empty() {
+                    *eof = true;
+                }
+                Poll::Ready(Ok(buf))
+            }
+            other => other,
+        }
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        self.project().0.consume(amt)
+    }
+}


### PR DESCRIPTION
If `multiple_members` is enabled, the `bufread::generic::Decoder` will
attempt to reinitialise the decoder inside `State::Flushing`, even if
the reason it entered that state was due to the reader returning an EOF.
This will result in an attempt to read past EOF, which is highly
undesirable to say the least.

To fix this, force `multiple_members` to `false` when we get an EOF
condition from the reader.