### PR TITLE
zstd: surface implicit default level `3` via libzstd constant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,7 @@ impl Level {
             Self::Fastest => 1,
             Self::Best => 21,
             Self::Precise(quality) => quality.min(21) as i32,
-            Self::Default => 0,
+            Self::Default => libzstd::DEFAULT_COMPRESSION_LEVEL,
         }
     }
 


### PR DESCRIPTION
instead of c-like flag `0`.

this implements #156, i hope it's helpful