### PR TITLE
Fix endianness when reading the `extra` field of a gzip header

### DIFF
--- a/src/codec/gzip/header.rs
+++ b/src/codec/gzip/header.rs
@@ -85,7 +85,7 @@ impl Parser {
                     data.copy_unwritten_from(input);
 
                     if data.unwritten().is_empty() {
-                        let len = u16::from_be_bytes(data.take().into_inner());
+                        let len = u16::from_le_bytes(data.take().into_inner());
                         self.state = State::Extra(vec![0; usize::from(len)].into());
                     } else {
                         return Ok(None);

--- a/tests/gzip.rs
+++ b/tests/gzip.rs
@@ -109,6 +109,7 @@ fn compress_with_header(data: &[u8]) -> Vec<u8> {
         let mut gz = GzBuilder::new()
             .filename("hello_world.txt")
             .comment("test file, please delete")
+            .extra(vec![1, 2, 3, 4])
             .write(&mut bytes, Compression::fast());
 
         gz.write_all(data).unwrap();


### PR DESCRIPTION
As specified in RFC1952 §2.1 multi-byte values are stored in little endian format.

Fixes #175 