### PR TITLE
Streaming encoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,7 @@ dependencies = [
  "tokio 0.2.25",
  "tokio 0.3.7",
  "tokio 1.15.0",
+ "tokio-stream",
  "tokio-util 0.3.1",
  "tokio-util 0.4.0",
  "tokio-util 0.5.1",
@@ -725,7 +726,7 @@ dependencies = [
  "memchr",
  "pin-project-lite 0.1.12",
  "slab",
- "tokio-macros",
+ "tokio-macros 0.2.6",
 ]
 
 [[package]]
@@ -750,6 +751,7 @@ dependencies = [
  "bytes 1.1.0",
  "memchr",
  "pin-project-lite 0.2.8",
+ "tokio-macros 1.8.0",
 ]
 
 [[package]]
@@ -761,6 +763,28 @@ dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.15",
  "syn 1.0.86",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+dependencies = [
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+dependencies = [
+ "futures-core",
+ "pin-project-lite 0.2.8",
+ "tokio 1.15.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 # groups
-default = []
+default = ["gzip", "tokio"]
 all = ["all-implementations", "all-algorithms"]
 all-implementations = ["futures-io", "stream", "tokio-02", "tokio-03", "tokio"]
 all-algorithms = ["brotli", "bzip2", "deflate", "gzip", "lzma", "xz", "zlib", "zstd"]
@@ -49,7 +49,7 @@ zstd-safe = { version = "5.0.1", optional = true, default-features = false }
 memchr = "2.2.1"
 tokio-02 = { package = "tokio", version = "0.2.21", optional = true, default-features = false }
 tokio-03 = { package = "tokio", version = "0.3.0", optional = true, default-features = false }
-tokio = { version = "1.0.0", optional = true, default-features = false }
+tokio = { version = "1.0.0", optional = true, default-features = false, features = ["time"] }
 
 [dev-dependencies]
 proptest = "1.0.0"
@@ -63,11 +63,12 @@ bytes-06 = { package = "bytes", version = "0.6.0" }
 bytes = "1.0.0"
 tokio-02 = { package = "tokio", version = "0.2.21", default-features = false, features = ["io-util", "stream", "macros", "io-std"] }
 tokio-03 = { package = "tokio", version = "0.3.0", default-features = false, features = ["io-util", "stream"] }
-tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
+tokio = { version = "1.0.0", default-features = false, features = ["io-util", "macros", "rt"] }
 tokio-util-03 = { package = "tokio-util", version = "0.3.0", default-features = false, features = ["codec"] }
 tokio-util-04 = { package = "tokio-util", version = "0.4.0", default-features = false, features = ["io"] }
 tokio-util-05 = { package = "tokio-util", version = "0.5.0", default-features = false, features = ["io"] }
 tokio-util-06 = { package = "tokio-util", version = "0.6.0", default-features = false, features = ["io"] }
+tokio-stream = { version = "0.1.11", features = ["time"] }
 
 [[test]]
 name = "brotli"

--- a/src/tokio/bufread/generic/encoder.rs
+++ b/src/tokio/bufread/generic/encoder.rs
@@ -4,7 +4,7 @@ use core::{
 };
 use std::io::Result;
 
-use crate::{codec::Encode, util::PartialBuffer};
+use crate::{codec::Encode, tokio::AsyncFlush, util::PartialBuffer};
 use futures_core::ready;
 use pin_project_lite::pin_project;
 use tokio::io::{AsyncBufRead, AsyncRead, ReadBuf};
@@ -112,6 +112,26 @@ impl<R: AsyncBufRead, E: Encode> AsyncRead for Encoder<R, E> {
                 buf.advance(len);
                 Poll::Ready(Ok(()))
             }
+        }
+    }
+}
+
+impl<R: AsyncBufRead, E: Encode> AsyncFlush for Encoder<R, E> {
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<Result<bool>> {
+        let mut output = PartialBuffer::new(buf.initialize_unfilled());
+        let mut this = self.project();
+
+        match this.encoder.flush(&mut output)? {
+            true => {
+                let len = output.written().len();
+                buf.advance(len);
+                Poll::Ready(Ok(true))
+            }
+            false => Poll::Ready(Ok(false)),
         }
     }
 }

--- a/src/tokio/bufread/macros/encoder.rs
+++ b/src/tokio/bufread/macros/encoder.rs
@@ -62,6 +62,16 @@ macro_rules! encoder {
             }
         }
 
+        impl<$inner: tokio::io::AsyncBufRead> crate::tokio::AsyncFlush for $name<$inner> {
+            fn poll_flush(
+                self: std::pin::Pin<&mut Self>,
+                cx: &mut std::task::Context<'_>,
+                buf: &mut tokio::io::ReadBuf<'_>,
+            ) -> std::task::Poll<std::io::Result<bool>> {
+                self.project().inner.poll_flush(cx, buf)
+            }
+        }
+
         const _: () = {
             fn _assert() {
                 use crate::util::{_assert_send, _assert_sync};

--- a/src/tokio/mod.rs
+++ b/src/tokio/mod.rs
@@ -1,7 +1,69 @@
 //! Implementations for IO traits exported by [`tokio` v1.0](::tokio).
 
+use std::{time::Duration, time::Instant};
+
+use futures_core::Future;
+use pin_project_lite::pin_project;
+use tokio::io::{AsyncBufRead, AsyncRead};
+
+use crate::codec::Encode;
+
+use self::bufread::Encoder;
+
 pub mod bufread;
 pub mod write;
+
+pin_project! {
+    pub struct StreamingEncoder<E: AsyncRead> {
+        #[pin]
+        encoder: E,
+        duration: Duration,
+        #[pin]
+        timeout: tokio::time::Sleep,
+    }
+}
+
+impl<E: AsyncRead + AsyncFlush> StreamingEncoder<E> {
+    pub fn new(encoder: E, timeout: Duration) -> Self {
+        let duration = timeout;
+        Self {
+            encoder,
+            duration,
+            timeout: tokio::time::sleep(timeout),
+        }
+    }
+}
+
+impl<E: AsyncRead + AsyncFlush> AsyncRead for StreamingEncoder<E> {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let mut this = self.project();
+
+        match this.encoder.as_mut().poll_read(cx, buf) {
+            std::task::Poll::Ready(r) => {
+                this.timeout
+                    .reset(tokio::time::Instant::now() + *this.duration);
+                std::task::Poll::Ready(r)
+            }
+            std::task::Poll::Pending => match this.timeout.as_mut().poll(cx) {
+                std::task::Poll::Pending => std::task::Poll::Pending,
+                std::task::Poll::Ready(()) => {
+                    this.timeout
+                        .reset(tokio::time::Instant::now() + *this.duration);
+                    match this.encoder.poll_flush(cx, buf) {
+                        std::task::Poll::Ready(Ok(true)) => std::task::Poll::Ready(Ok(())),
+                        std::task::Poll::Ready(Ok(false)) => std::task::Poll::Pending,
+                        std::task::Poll::Ready(Err(e)) => std::task::Poll::Ready(Err(e)),
+                        std::task::Poll::Pending => std::task::Poll::Pending,
+                    }
+                }
+            },
+        }
+    }
+}
 
 pub trait AsyncFlush {
     fn poll_flush(

--- a/src/tokio/mod.rs
+++ b/src/tokio/mod.rs
@@ -2,3 +2,11 @@
 
 pub mod bufread;
 pub mod write;
+
+pub trait AsyncFlush {
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<bool>>;
+}

--- a/tests/gzip.rs
+++ b/tests/gzip.rs
@@ -165,3 +165,59 @@ fn gzip_bufread_chunks_decompress_with_extra_header() {
 
     assert_eq!(output, &[1, 2, 3, 4, 5, 6][..]);
 }
+
+use std::time::Duration;
+
+use async_compression::tokio::{bufread::GzipEncoder, StreamingEncoder};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    time,
+};
+
+#[tokio::test]
+async fn test() {
+    let (mut client, server) = tokio::io::duplex(1024);
+    tokio::task::spawn(async move {
+        loop {
+            client
+                .write_all(&std::iter::repeat(b'A').take(256).collect::<Vec<_>>())
+                .await
+                .unwrap();
+            println!("sent data: 256 bytes");
+            time::sleep(Duration::from_millis(100)).await;
+        }
+    });
+
+    let mut encoder = GzipEncoder::new(tokio::io::BufReader::new(server));
+    //if this is commented out, the test will fail
+    let mut encoder = Box::pin(StreamingEncoder::new(encoder, Duration::from_millis(250)));
+
+    let mut buf = std::iter::repeat(0u8).take(1024).collect::<Vec<_>>();
+
+    let start = std::time::Instant::now();
+    let mut counter = 0usize;
+    println!("start");
+    loop {
+        let read = encoder.read(&mut buf);
+        match time::timeout(Duration::from_secs(5), read).await {
+            Err(e) => {
+                panic!("{}ms | timeout: {:?}", start.elapsed().as_millis(), e);
+            }
+
+            Ok(res) => {
+                println!(
+                    "{}ms | received data: {:?}",
+                    start.elapsed().as_millis(),
+                    res
+                );
+
+                counter += 1;
+                if counter == 10 {
+                    break;
+                }
+            }
+        }
+    }
+
+    //panic!();
+}


### PR DESCRIPTION
Fix #154 

:warning: not ready yet, only the bare minimum was done to validate it in tokio and gzip, the rest wil come later

this is a follow up on the proposal for a `poll_flush` implementation. It is implemented on `tokio::bufread::Encoder` and in the macros. We then provide a `StreamingEncoder` that wraps a `AsyncRead` and `AsyncFlush` implementation to flush it if it produced nothing after a configurable time.

The test shows it appears  to work, but I'd like to test it more using the proptest integration.
On the API side, I think it will look better as a `.flush_timeout()` method?

I looked into flushing once a configurable amount of data has been passed, but that requires hooking the data producer to count the bytes passing through, pass it to the `Encoder`, then have the `StreamingEncoder` monitor that count. That's a bit involved, maybe that could be a separate implementation.